### PR TITLE
defer marking temp file for deletion

### DIFF
--- a/loaders/common.py
+++ b/loaders/common.py
@@ -1,5 +1,6 @@
 import tempfile
 import time 
+import os
 from utils import compute_sha1_from_file
 from langchain.schema import Document
 import streamlit as st
@@ -23,7 +24,7 @@ def process_file(vector_store, file, loader_class, file_suffix, stats_db=None):
         loader = loader_class(tmp_file.name)
         documents = loader.load()
         file_sha1 = compute_sha1_from_file(tmp_file.name)
-        tmp_file.delete = True
+    os.remove(tmp_file.name)
     
     chunk_size = st.session_state['chunk_size']
     chunk_overlap = st.session_state['chunk_overlap']

--- a/loaders/common.py
+++ b/loaders/common.py
@@ -16,13 +16,14 @@ def process_file(vector_store, file, loader_class, file_suffix, stats_db=None):
             st.error("File size is too large. Please upload a file smaller than 1MB or self host.")
             return
     dateshort = time.strftime("%Y%m%d")
-    with tempfile.NamedTemporaryFile(delete=True, suffix=file_suffix) as tmp_file:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=file_suffix) as tmp_file:
         tmp_file.write(file.getvalue())
         tmp_file.flush()
 
         loader = loader_class(tmp_file.name)
         documents = loader.load()
         file_sha1 = compute_sha1_from_file(tmp_file.name)
+        tmp_file.delete = True
     
     chunk_size = st.session_state['chunk_size']
     chunk_overlap = st.session_state['chunk_overlap']


### PR DESCRIPTION
closes #38

I did some digging and this seems to be a recurring theme with [`tempfile.NamedTemporaryFile()`](https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile) not being completely cross-platform. According to the python docs you can't open a tempfile more than once on windows. 
> Whether the name can be used to open the file a second time, while the named temporary file is still open, varies across platforms (it can be so used on Unix; it cannot on Windows).

I aimed to make the minimum viable change that would fix the issue. All I have done here is to disable automatic cleanup and then clean it up manually. Some commenters on S.O. [suggested](https://stackoverflow.com/questions/23212435/permission-denied-to-write-to-my-temporary-file) rolling your own to avoid the cross-platform issues. According to official python docs [`os.remove()`](https://docs.python.org/3/library/os.html#os.remove) is fully cross-platform. However, I see that this is built on top of langchain, which seems to make heavy use of `tempfile.NamedTemporaryFile()` so it may not be feasible to migrate to a different file handling approach. I haven't scanned the rest of the Quivr codebase yet, but if this is the only place where file I/O occurs then this patch might be enough to close the books on this.

I tested on my machine by uploading a csv, txt, and pdf. I watched as each file was placed in the temp directory and then saw each get cleaned up. 

Sidenote: I am not a python expert, so maybe this is normal, but I would expect `tmp_file` to be out of scope upon exiting the `with` block. However, I had no issues using it after exiting that scope. Anyone see anything concerning here?
