### PR TITLE
fix content scraping/exploring

### DIFF
--- a/explorer.py
+++ b/explorer.py
@@ -1,12 +1,21 @@
 import streamlit as st
 
+def show_document(document):
+    st.write("**Document Content**")
+    st.write(document)
 
 def view_document(supabase):
     # Get the document from the database
     response = supabase.table("documents").select("content").execute()
     st.write("**This feature is in active development**")
+    st.write("**Document List**")
+
     # Display a list of elements from the documents
     # If the user clicks on an element, display the content of the document
-    for document in response.data:
-        if st.button(document['content'][:50].replace("\n", " ")):
-            continue
+    selected_document = None
+    for index, document in enumerate(response.data):
+        if st.button(document['content'][:50].replace("\n", " "), key=f"document_button_{index}"):
+            selected_document = document['content']
+    
+    if selected_document:
+        show_document(selected_document)

--- a/loaders/html.py
+++ b/loaders/html.py
@@ -22,7 +22,7 @@ def get_html(url):
 def create_html_file(url, content):
     file_name = slugify(url) + ".html"
     temp_file_path = os.path.join(tempfile.gettempdir(), file_name)
-    with open(temp_file_path, 'w') as temp_file:
+    with open(temp_file_path, "w", encoding="utf-8") as temp_file:
         temp_file.write(content)
 
     record = UploadedFileRec(id=None, name=file_name, type='text/html', data=open(temp_file_path, 'rb').read())


### PR DESCRIPTION
- Fix UnicodeEncodeError while trying to encode a character that is not supported by the 'charmap' codec

example error fix:
`UnicodeEncodeError: 'charmap' codec can't encode character '\u2192' in position 29383: character maps to <undefined>`

- fixed exploring content