### PR TITLE
fix(51): Catch UnicodeEncodeError exception

### DIFF
--- a/files.py
+++ b/files.py
@@ -79,7 +79,10 @@ def url_uploader(supabase, openai_key, vector_store):
                 html = get_html(url)
                 if html:
                     st.write(f"Getting content ... {url}  ")
-                    file, temp_file_path = create_html_file(url, html)
+                    try:
+                        file, temp_file_path = create_html_file(url, html)
+                    except UnicodeEncodeError as e:
+                        st.write(f"❌ Error encoding character: {e}")
                     ret = filter_file(file, supabase, vector_store)
                     delete_tempfile(temp_file_path, url, ret)
                 else:


### PR DESCRIPTION
When there is a unicode character in URL of website, your app fails.
![image](https://github.com/StanGirard/quivr/assets/65130881/164d6584-74eb-4f94-8163-e1a3163d644c)

I have added a try catch block and have printed the error in the standard output.

Fixes: https://github.com/StanGirard/quivr/issues/51