### PR TITLE
Fix a bug where langchain memories were not being cleaned

### DIFF
--- a/question.py
+++ b/question.py
@@ -41,6 +41,8 @@ def chat_with_doc(model, vector_store: SupabaseVectorStore, stats_db):
     
     
     if clear_history:
+        # Clear memory in Langchain
+        memory.clear()
         st.session_state['chat_history'] = []
         st.experimental_rerun()
 


### PR DESCRIPTION
When the user clicks Clear, the records in memory should be cleared at the same time. Otherwise, the memory record will always exist unless restarted.