### PR TITLE
tiangolo domain is not necessary

### DIFF
--- a/v2/api.py
+++ b/v2/api.py
@@ -17,8 +17,6 @@ from fastapi.middleware.cors import CORSMiddleware
 app = FastAPI()
 
 origins = [
-    "http://localhost.tiangolo.com",
-    "https://localhost.tiangolo.com",
     "http://localhost",
     "http://localhost:3000",
     "http://localhost:8080",


### PR DESCRIPTION
localhost.tiangolo.com domain is not necessary to enable cors since this domain is belong to tiangolo himself.