### PR TITLE
add docx2txt package for uploading word docs

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,4 @@ anthropic==0.2.8
 fastapi==0.95.2
 python-multipart==0.0.6
 uvicorn==0.22.0
+docx2txt==0.8


### PR DESCRIPTION
# About
When I upload a word doc I get the following error:
```
ModuleNotFoundError: No module named 'docx2txt'
```

# Proof
Uploading a word doc succeeds:
![Screenshot 2023-05-20 191826](https://github.com/StanGirard/quivr/assets/45178375/39ad1364-299e-45b5-b87c-537c4c338135)
