### PR TITLE
set pip timeout to 100 second (default 15)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /code
 
 COPY ./requirements.txt /code/requirements.txt
 
-RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt --timeout 100
 
 COPY . /code/
 


### PR DESCRIPTION
Some python package is too large, 15 seconds to download isn't sufficient, I expand this timeout to 100 seconds but you may varies this as you see fit. It's not affect overall build time for regular user, just expand the room for slow network user.