### PR TITLE
feat(toast): use id for open status toggling

### DIFF
--- a/frontend/app/components/ui/Toast/components/Toast.tsx
+++ b/frontend/app/components/ui/Toast/components/Toast.tsx
@@ -18,12 +18,12 @@ export const Toast = ({
       <ToastContext.Provider value={{ publish }}>
         {children}
         <AnimatePresence mode="popLayout">
-          {toasts.map((toast, index) => {
+          {toasts.map((toast) => {
             if (!toast.open) return;
             return (
               <ToastPrimitive.Root
                 open={toast.open}
-                onOpenChange={(value) => toggleToast(value, index)}
+                onOpenChange={(value) => toggleToast(value, toast.id)}
                 asChild
                 forceMount
                 key={toast.id}

--- a/frontend/app/components/ui/Toast/hooks/useToastBuilder.ts
+++ b/frontend/app/components/ui/Toast/hooks/useToastBuilder.ts
@@ -6,10 +6,10 @@ import { generateToastUniqueId } from "../helpers/generateToastUniqueId";
 export const useToastBuilder = () => {
   const [toasts, setToasts] = useState<ToastContent[]>([]);
 
-  const toggleToast = (value: boolean, index: number) => {
+  const toggleToast = (value: boolean, toastId: string) => {
     setToasts((toasts) =>
-      toasts.map((toast, i) => {
-        if (i === index) {
+      toasts.map((toast) => {
+        if (toast.id === toastId) {
           toast.open = value;
         }
         return toast;


### PR DESCRIPTION
# Description

This PR use toast id for open status toggling, instead of index

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas
- [x] Any dependent changes have been merged

## Screenshots (if appropriate):
