### PR TITLE
more specific prompt for reponse in different language, add qa_prompt…

### DIFF
--- a/backend/llm/LANGUAGE_PROMPT.py
+++ b/backend/llm/LANGUAGE_PROMPT.py
@@ -1,6 +1,6 @@
 from langchain.prompts.prompt import PromptTemplate
 
-_template = """Given the following conversation and a follow up question, answer the follow up question in the initial language of the question. If you don't know the answer, just say that you don't know, don't try to make up an answer.
+_template = """Given the following conversation and a follow up question. User's question might be in different language each time, response needs to be in the same language as user's current question everytime. If you don't know the answer, just say that you don't know, don't try to make up an answer.
 
 Chat History:
 {chat_history}
@@ -8,8 +8,7 @@ Follow Up Input: {question}
 Standalone question:"""
 CONDENSE_QUESTION_PROMPT = PromptTemplate.from_template(_template)
 
-prompt_template = """Use the following pieces of context to answer the question in the language of the question. If you don't know the answer, just say that you don't know, don't try to make up an answer. 
-
+prompt_template = """Use the following pieces of context to answer. User's question might be in different language each time, response needs to be in the same language as user's current question everytime. If you don't know the answer, just say that you don't know, don't try to make up an answer.
 {context}
 
 Question: {question}

--- a/backend/llm/qa.py
+++ b/backend/llm/qa.py
@@ -26,11 +26,10 @@ memory = ConversationBufferMemory(
 def get_qa_llm(chat_message: ChatMessage):
     qa = None
     # this overwrites the built-in prompt of the ConversationalRetrievalChain
-    ConversationalRetrievalChain.prompts = LANGUAGE_PROMPT
     if chat_message.model.startswith("gpt"):
         qa = ConversationalRetrievalChain.from_llm(
             OpenAI(
-                model_name=chat_message.model, openai_api_key=openai_api_key, temperature=chat_message.temperature, max_tokens=chat_message.max_tokens), vector_store.as_retriever(), memory=memory, verbose=False, max_tokens_limit=1024)
+                model_name=chat_message.model, openai_api_key=openai_api_key, temperature=chat_message.temperature, max_tokens=chat_message.max_tokens), vector_store.as_retriever(), memory=memory, verbose=False, max_tokens_limit=1024, combine_docs_chain_kwargs={'prompt': LANGUAGE_PROMPT.QA_PROMPT}, condense_question_prompt=LANGUAGE_PROMPT.CONDENSE_QUESTION_PROMPT)
     elif anthropic_api_key and chat_message.model.startswith("claude"):
         qa = ConversationalRetrievalChain.from_llm(
             ChatAnthropic(


### PR DESCRIPTION
It seems to be able to fix the issue from issue #141 for me when I added qa_prompt and condense_question_prompt to ConversationalRetrievalChain.from_llm instead of overwriting the built-in prompt of the ConversationalRetrievalChain using "ConversationalRetrievalChain.prompts = LANGUAGE_PROMPT" 

screen shot of chat before the change: 
![image](https://github.com/StanGirard/quivr/assets/51186185/405d6f7f-bd9d-4368-a33f-b85bc62cb1d6)
screen shot of chat after the change:
![image](https://github.com/StanGirard/quivr/assets/51186185/cd895c08-5864-482c-a6d9-a436241a8a72)
