### PR TITLE
Sticky - chat list, navbar, chat input

### DIFF
--- a/frontend/app/(auth)/login/page.tsx
+++ b/frontend/app/(auth)/login/page.tsx
@@ -47,7 +47,7 @@ export default function Login() {
 
   return (
     <main>
-      <section className="w-full min-h-screen h-full outline-none flex flex-col gap-5 items-center justify-center p-6">
+      <section className="w-full min-h-[80vh] h-full outline-none flex flex-col gap-5 items-center justify-center p-6">
         <PageHeading title="Login" subtitle="Welcome back" />
         <Card className="max-w-md w-full p-5 sm:p-10 text-left">
           <form

--- a/frontend/app/(auth)/logout/page.tsx
+++ b/frontend/app/(auth)/logout/page.tsx
@@ -37,7 +37,7 @@ export default function Logout() {
 
   return (
     <main>
-      <section className="w-full min-h-screen h-full outline-none flex flex-col gap-5 items-center justify-center p-6">
+      <section className="w-full min-h-[80vh] h-full outline-none flex flex-col gap-5 items-center justify-center p-6">
         <PageHeading title="Logout" subtitle="See you next time" />
         <Card className="max-w-md w-full p-5 sm:p-10 text-center flex flex-col items-center gap-5">
           <h2 className="text-lg">Are you sure you want to sign out?</h2>

--- a/frontend/app/(auth)/signup/page.tsx
+++ b/frontend/app/(auth)/signup/page.tsx
@@ -39,7 +39,7 @@ export default function SignUp() {
 
   return (
     <main>
-      <section className="min-h-screen w-full h-full outline-none flex flex-col gap-5 items-center justify-center p-6">
+      <section className="min-h-[80vh] w-full h-full outline-none flex flex-col gap-5 items-center justify-center p-6">
         <PageHeading title="Sign Up" subtitle="Create your account" />
         <Card className="max-w-md w-full p-5 sm:p-10 text-left">
           <form

--- a/frontend/app/chat/[chatId]/page.tsx
+++ b/frontend/app/chat/[chatId]/page.tsx
@@ -17,13 +17,17 @@ export default function ChatPage({ params }: ChatPageProps) {
 
   return (
     <main className="flex flex-col w-full pt-10">
-      <section className="flex flex-col items-center w-full overflow-auto">
+      <section className="flex flex-col flex-1 items-center w-full h-full min-h-screen">
         <PageHeading
           title="Chat with your brain"
           subtitle="Talk to a language model about your uploaded data"
         />
-        {chat && <ChatMessages chat={chat} />}
-        <ChatInput chatId={chatId} {...others} />
+        <div className="relative h-full w-full flex flex-col flex-1">
+          <div className="h-full flex-1">
+            {chat && <ChatMessages chat={chat} />}
+          </div>
+          <ChatInput chatId={chatId} {...others} />
+        </div>
       </section>
     </main>
   );

--- a/frontend/app/chat/[chatId]/page.tsx
+++ b/frontend/app/chat/[chatId]/page.tsx
@@ -22,8 +22,8 @@ export default function ChatPage({ params }: ChatPageProps) {
           title="Chat with your brain"
           subtitle="Talk to a language model about your uploaded data"
         />
-        <div className="relative h-full w-full flex flex-col flex-1">
-          <div className="h-full flex-1">
+        <div className="relative h-full w-full flex flex-col flex-1 items-center">
+          <div className="h-full flex-1 w-full">
             {chat && <ChatMessages chat={chat} />}
           </div>
           <ChatInput chatId={chatId} {...others} />

--- a/frontend/app/chat/[chatId]/page.tsx
+++ b/frontend/app/chat/[chatId]/page.tsx
@@ -23,7 +23,7 @@ export default function ChatPage({ params }: ChatPageProps) {
           subtitle="Talk to a language model about your uploaded data"
         />
         <div className="relative h-full w-full flex flex-col flex-1 items-center">
-          <div className="h-full flex-1 w-full">
+          <div className="h-full flex-1 w-full flex flex-col items-center">
             {chat && <ChatMessages chat={chat} />}
           </div>
           <ChatInput chatId={chatId} {...others} />

--- a/frontend/app/chat/[chatId]/page.tsx
+++ b/frontend/app/chat/[chatId]/page.tsx
@@ -16,7 +16,7 @@ export default function ChatPage({ params }: ChatPageProps) {
   const { chat, ...others } = useChats(chatId);
 
   return (
-    <main className="flex flex-col w-full">
+    <main className="flex flex-col w-full pt-10">
       <section className="flex flex-col items-center w-full overflow-auto">
         <PageHeading
           title="Chat with your brain"

--- a/frontend/app/chat/components/ChatMessages/ChatInput/index.tsx
+++ b/frontend/app/chat/components/ChatMessages/ChatInput/index.tsx
@@ -27,7 +27,7 @@ export function ChatInput({
         e.preventDefault();
         if (!isSendingMessage) sendMessage(chatId);
       }}
-      className="sticky bottom-0 p-5 bg-white dark:bg-black rounded-t-md border border-black/10 dark:border-white/25 w-full max-w-3xl flex items-center justify-center gap-2 z-20"
+      className="sticky bottom-0 p-5 bg-white dark:bg-black rounded-t-md border border-black/10 dark:border-white/25 border-b-0 w-full max-w-3xl flex items-center justify-center gap-2 z-20"
     >
       <textarea
         autoFocus

--- a/frontend/app/chat/components/ChatMessages/ChatInput/index.tsx
+++ b/frontend/app/chat/components/ChatMessages/ChatInput/index.tsx
@@ -27,7 +27,7 @@ export function ChatInput({
         e.preventDefault();
         if (!isSendingMessage) sendMessage(chatId);
       }}
-      className="fixed p-5 bg-white dark:bg-black rounded-t-md border border-black/10 dark:border-white/25 bottom-0 w-full max-w-3xl flex items-center justify-center gap-2 z-20"
+      className="sticky bottom-0 p-5 bg-white dark:bg-black rounded-t-md border border-black/10 dark:border-white/25 w-full max-w-3xl flex items-center justify-center gap-2 z-20"
     >
       <textarea
         autoFocus

--- a/frontend/app/chat/components/ChatMessages/index.tsx
+++ b/frontend/app/chat/components/ChatMessages/index.tsx
@@ -13,7 +13,9 @@ export const ChatMessages = ({ chat }: ChatMessagesProps): JSX.Element => {
   const lastChatRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
-    lastChatRef.current?.scrollIntoView({ behavior: "auto", block: "start" });
+    if (chat.history.length > 2) {
+      lastChatRef.current?.scrollIntoView({ behavior: "auto", block: "start" });
+    }
   }, [chat]);
 
   return (

--- a/frontend/app/chat/components/ChatMessages/index.tsx
+++ b/frontend/app/chat/components/ChatMessages/index.tsx
@@ -19,7 +19,7 @@ export const ChatMessages = ({ chat }: ChatMessagesProps): JSX.Element => {
   }, [chat]);
 
   return (
-    <Card className="p-5 max-w-3xl w-full flex-1 flex flex-col h-full mb-8">
+    <Card className="p-5 max-w-3xl w-full flex flex-col h-full mb-8">
       <div className="flex-1">
         {chat.history.length === 0 ? (
           <div className="text-center opacity-50">

--- a/frontend/app/chat/components/ChatMessages/index.tsx
+++ b/frontend/app/chat/components/ChatMessages/index.tsx
@@ -17,8 +17,8 @@ export const ChatMessages = ({ chat }: ChatMessagesProps): JSX.Element => {
   }, [chat]);
 
   return (
-    <Card className="p-5 max-w-3xl w-full flex-1 flex flex-col mb-8">
-      <div className="">
+    <Card className="p-5 max-w-3xl w-full flex-1 flex flex-col h-full mb-8">
+      <div className="flex-1">
         {chat.history.length === 0 ? (
           <div className="text-center opacity-50">
             Ask a question, or describe a task.

--- a/frontend/app/chat/components/ChatsList/ChatsListItem.tsx
+++ b/frontend/app/chat/components/ChatsList/ChatsListItem.tsx
@@ -20,7 +20,9 @@ const ChatsListItem: FC<ChatsListItemProps> = ({ chat, deleteChat }) => {
     <div
       className={cn(
         "w-full border-b border-black/10 dark:border-white/25 last:border-none relative group flex overflow-x-hidden hover:bg-gray-100 dark:hover:bg-gray-800",
-        selected ? "bg-gray-100 text-primary" : ""
+        selected
+          ? "bg-gray-100 dark:bg-gray-800 text-primary dark:text-white"
+          : ""
       )}
     >
       <Link

--- a/frontend/app/chat/components/ChatsList/NewChatButton.tsx
+++ b/frontend/app/chat/components/ChatsList/NewChatButton.tsx
@@ -4,7 +4,7 @@ import { BsPlusSquare } from "react-icons/bs";
 export const NewChatButton = () => (
   <Link
     href="/chat"
-    className="px-4 py-2 mx-4 my-2 border border-primary hover:text-white hover:bg-primary shadow-lg rounded-lg flex items-center justify-center"
+    className="px-4 py-2 mx-4 my-2 border border-primary bg-white dark:bg-black hover:text-white hover:bg-primary shadow-lg rounded-lg flex items-center justify-center sticky top-2 z-10"
   >
     <BsPlusSquare className="h-6 w-6 mr-2" /> New Chat
   </Link>

--- a/frontend/app/chat/components/ChatsList/NewChatButton.tsx
+++ b/frontend/app/chat/components/ChatsList/NewChatButton.tsx
@@ -4,7 +4,7 @@ import { BsPlusSquare } from "react-icons/bs";
 export const NewChatButton = () => (
   <Link
     href="/chat"
-    className="px-4 py-2 mx-4 my-2 border border-primary bg-white dark:bg-black hover:text-white hover:bg-primary shadow-lg rounded-lg flex items-center justify-center sticky top-2 z-10"
+    className="px-4 py-2 mx-4 my-2 border border-primary bg-white dark:bg-black hover:text-white hover:bg-primary shadow-lg rounded-lg flex items-center justify-center sticky top-2 z-20"
   >
     <BsPlusSquare className="h-6 w-6 mr-2" /> New Chat
   </Link>

--- a/frontend/app/chat/components/ChatsList/index.tsx
+++ b/frontend/app/chat/components/ChatsList/index.tsx
@@ -5,7 +5,7 @@ import { NewChatButton } from "./NewChatButton";
 export function ChatsList() {
   const { allChats, deleteChat } = useChats();
   return (
-    <aside className="h-screen bg-white dark:bg-black max-w-xs w-full border-r border-black/10 dark:border-white/25 ">
+    <aside className="bg-white dark:bg-black max-w-xs w-full border-r border-black/10 dark:border-white/25 ">
       <NewChatButton />
       <div className="flex flex-col gap-0">
         {allChats.map((chat) => (

--- a/frontend/app/chat/components/ChatsList/index.tsx
+++ b/frontend/app/chat/components/ChatsList/index.tsx
@@ -6,7 +6,7 @@ export function ChatsList() {
   const { allChats, deleteChat } = useChats();
   return (
     <div className="sticky top-0 max-h-screen overflow-auto scrollbar">
-      <aside className="relative bg-white dark:bg-black max-w-xs w-full border-r border-black/10 dark:border-white/25 ">
+      <aside className="relative bg-white dark:bg-black max-w-xs w-full border-r border-black/10 dark:border-white/25 h-screen">
         <NewChatButton />
         <div className="flex flex-col gap-0">
           {allChats.map((chat) => (

--- a/frontend/app/chat/components/ChatsList/index.tsx
+++ b/frontend/app/chat/components/ChatsList/index.tsx
@@ -5,17 +5,19 @@ import { NewChatButton } from "./NewChatButton";
 export function ChatsList() {
   const { allChats, deleteChat } = useChats();
   return (
-    <aside className="relative bg-white dark:bg-black max-w-xs w-full border-r border-black/10 dark:border-white/25 ">
-      <NewChatButton />
-      <div className="flex flex-col gap-0 pb-32">
-        {allChats.map((chat) => (
-          <ChatsListItem
-            key={chat.chatId}
-            chat={chat}
-            deleteChat={deleteChat}
-          />
-        ))}
-      </div>
-    </aside>
+    <div className="sticky top-0 max-h-screen overflow-auto scrollbar">
+      <aside className="relative bg-white dark:bg-black max-w-xs w-full border-r border-black/10 dark:border-white/25 ">
+        <NewChatButton />
+        <div className="flex flex-col gap-0">
+          {allChats.map((chat) => (
+            <ChatsListItem
+              key={chat.chatId}
+              chat={chat}
+              deleteChat={deleteChat}
+            />
+          ))}
+        </div>
+      </aside>
+    </div>
   );
 }

--- a/frontend/app/chat/components/ChatsList/index.tsx
+++ b/frontend/app/chat/components/ChatsList/index.tsx
@@ -5,9 +5,9 @@ import { NewChatButton } from "./NewChatButton";
 export function ChatsList() {
   const { allChats, deleteChat } = useChats();
   return (
-    <aside className="bg-white dark:bg-black max-w-xs w-full border-r border-black/10 dark:border-white/25 ">
+    <aside className="relative bg-white dark:bg-black max-w-xs w-full border-r border-black/10 dark:border-white/25 ">
       <NewChatButton />
-      <div className="flex flex-col gap-0">
+      <div className="flex flex-col gap-0 pb-32">
         {allChats.map((chat) => (
           <ChatsListItem
             key={chat.chatId}

--- a/frontend/app/chat/layout.tsx
+++ b/frontend/app/chat/layout.tsx
@@ -13,8 +13,8 @@ const Layout: FC<LayoutProps> = ({ children }) => {
   if (!session) redirect("/login");
 
   return (
-    <div className="relative h-full w-full flex pt-20">
-      <div className="h-full">
+    <div className="relative h-full w-full flex items-start">
+      <div className="sticky top-0 max-h-screen overflow-auto">
         <ChatsList />
       </div>
       {children}

--- a/frontend/app/chat/layout.tsx
+++ b/frontend/app/chat/layout.tsx
@@ -14,9 +14,7 @@ const Layout: FC<LayoutProps> = ({ children }) => {
 
   return (
     <div className="relative h-full w-full flex items-start">
-      <div className="sticky top-0 max-h-screen overflow-auto">
-        <ChatsList />
-      </div>
+      <ChatsList />
       {children}
     </div>
   );

--- a/frontend/app/components/Footer/index.tsx
+++ b/frontend/app/components/Footer/index.tsx
@@ -1,6 +1,6 @@
 const Footer = () => {
   return (
-    <footer className="bg-white dark:bg-black border-t dark:border-white/10 py-4 mt-auto">
+    <footer className="bg-white dark:bg-black border-t dark:border-white/10 mt-auto py-10">
       <div className="max-w-screen-xl mx-auto flex justify-center items-center gap-4">
         <a
           href="https://github.com/stangirard/quivr"
@@ -8,7 +8,11 @@ const Footer = () => {
           rel="noopener noreferrer"
           aria-label="Quivr GitHub"
         >
-          <img className="h-8 w-auto" src="/github.svg" alt="GitHub" />
+          <img
+            className="h-8 w-auto dark:invert"
+            src="/github.svg"
+            alt="GitHub"
+          />
         </a>
         <a
           href="https://twitter.com/quivr_brain"

--- a/frontend/app/components/NavBar/components/Header/index.tsx
+++ b/frontend/app/components/NavBar/components/Header/index.tsx
@@ -10,7 +10,7 @@ export const Header = ({ children }: { children: React.ReactNode }) => {
         y: hidden ? "-100%" : "0%",
         transition: { ease: "circOut" },
       }}
-      className="fixed top-0 w-full border-b border-b-black/10 dark:border-b-white/25 bg-white dark:bg-black z-20"
+      className="sticky top-0 w-full border-b border-b-black/10 dark:border-b-white/25 bg-white dark:bg-black z-20"
     >
       <nav className="max-w-screen-xl mx-auto py-1 flex items-center justify-between gap-8">
         {children}

--- a/frontend/app/config/page.tsx
+++ b/frontend/app/config/page.tsx
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 import {
   anthropicModels,
   models,
-  paidModels
+  paidModels,
 } from "@/lib/context/BrainConfigProvider/types";
 import Link from "next/link";
 import Button from "../components/ui/Button";
@@ -26,14 +26,13 @@ export default function ExplorePage() {
     resetBrainConfig,
   } = useConfig();
 
-  
   if (session === null) {
     redirect("/login");
   }
 
   return (
     <main className="w-full flex flex-col">
-      <section className="w-full outline-none pt-32 flex flex-col gap-5 items-center justify-center p-6">
+      <section className="w-full outline-none pt-10 flex flex-col gap-5 items-center justify-center p-6">
         <div className="flex flex-col items-center justify-center">
           <h1 className="text-3xl font-bold text-center">Configuration</h1>
           <h2 className="opacity-50 text-center">

--- a/frontend/app/explore/page.tsx
+++ b/frontend/app/explore/page.tsx
@@ -42,7 +42,7 @@ export default function ExplorePage() {
 
   return (
     <main>
-      <section className="w-full outline-none pt-32 flex flex-col gap-5 items-center justify-center p-6">
+      <section className="w-full outline-none pt-10 flex flex-col gap-5 items-center justify-center p-6">
         <div className="flex flex-col items-center justify-center">
           <h1 className="text-3xl font-bold text-center">
             Explore uploaded data

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -34,8 +34,7 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`bg-white text-black dark:bg-black dark:text-white w-full ${inter.className}`}
-        style={{ minHeight: "100vh", display: "flex", flexDirection: "column" }}
+        className={`bg-white text-black min-h-screen flex flex-col dark:bg-black dark:text-white w-full ${inter.className}`}
       >
         <ToastProvider>
           <SupabaseProvider session={session}>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -41,9 +41,7 @@ export default async function RootLayout({
             <BrainConfigProvider>
               <NavBar />
               <div className="flex-1">{children}</div>
-              <div className="mt-20">
-                <Footer />
-              </div>
+              <Footer />
             </BrainConfigProvider>
           </SupabaseProvider>
         </ToastProvider>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -40,8 +40,8 @@ export default async function RootLayout({
           <SupabaseProvider session={session}>
             <BrainConfigProvider>
               <NavBar />
-              <div style={{ flex: "1 0 auto" }}>{children}</div>
-              <div style={{ position: "sticky", bottom: 0 }}>
+              <div className="flex-1">{children}</div>
+              <div className="mt-20">
                 <Footer />
               </div>
             </BrainConfigProvider>

--- a/frontend/app/upload/page.tsx
+++ b/frontend/app/upload/page.tsx
@@ -8,7 +8,7 @@ import { FileUploader } from "./components/FileUploader";
 
 export default function UploadPage() {
   return (
-    <main className="pt-24">
+    <main className="pt-10">
       <PageHeading
         title="Upload Knowledge"
         subtitle="Text, document, spreadsheet, presentation, audio, video, and URLs supported"

--- a/frontend/app/user/page.tsx
+++ b/frontend/app/user/page.tsx
@@ -40,7 +40,7 @@ export default function UserPage() {
   }, [session.access_token]);
 
   return (
-    <main className="w-full flex flex-col pt-32">
+    <main className="w-full flex flex-col pt-10">
       <section className="flex flex-col justify-center items-center flex-1 gap-5 h-full">
         <div className="p-5 max-w-3xl w-full min-h-full flex-1 mb-24">
           {userStats ? (


### PR DESCRIPTION
# Description

This PR makes some UX improvements on majorly the `/chat` page.
- Sticky navbar - to not have an arbitrary padding top on every page
- Sticky chatlist - to not having to scroll to the top everytime you want to switch to another chat
- Footer is now static instead of sticky 
- Chat input is also sticky to avoid overlap with the footer

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas
- [x] Any dependent changes have been merged

# Video:

https://github.com/StanGirard/quivr/assets/61308761/76251809-73a2-4522-ab49-880541a19e95


