### PR TITLE
Feat/add new openai llm models

### DIFF
--- a/backend/llm/summarization.py
+++ b/backend/llm/summarization.py
@@ -9,7 +9,7 @@ logger = get_logger(__name__)
 
 openai_api_key = os.environ.get("OPENAI_API_KEY")
 openai.api_key = openai_api_key
-summary_llm = guidance.llms.OpenAI('gpt-3.5-turbo', caching=False)
+summary_llm = guidance.llms.OpenAI('gpt-3.5-turbo-0613', caching=False)
 
 
 def llm_summerize(document):
@@ -40,7 +40,7 @@ def llm_evaluate_summaries(question, summaries, model):
     if not model.startswith('gpt'):
         logger.info(
             f'Model {model} not supported. Using gpt-3.5-turbo instead.')
-        model = 'gpt-3.5-turbo'
+        model = 'gpt-3.5-turbo-0613'
     logger.info(f'Evaluating summaries with {model}')
     evaluation_llm = guidance.llms.OpenAI(model, caching=False)
     evaluation = guidance("""

--- a/backend/models/chats.py
+++ b/backend/models/chats.py
@@ -5,11 +5,11 @@ from pydantic import BaseModel
 
 
 class ChatMessage(BaseModel):
-    model: str = "gpt-3.5-turbo"
+    model: str = "gpt-3.5-turbo-0613"
     question: str
     # A list of tuples where each tuple is (speaker, text)
     history: List[Tuple[str, str]]
     temperature: float = 0.0
     max_tokens: int = 256
     use_summarization: bool = False
-    chat_id: Optional[UUID] = None, 
+    chat_id: Optional[UUID] = None,

--- a/frontend/app/config/components/ModelConfig.tsx
+++ b/frontend/app/config/components/ModelConfig.tsx
@@ -34,7 +34,7 @@ export const ModelConfig = ({
       case "gpt-3.5-turbo-0613":
         return 3000;
       case "gpt-3.5-turbo-16k":
-        return 15000;
+        return 14000;
       case "gpt-4":
         return 6000;
       case "gpt-4-0613":

--- a/frontend/app/config/components/ModelConfig.tsx
+++ b/frontend/app/config/components/ModelConfig.tsx
@@ -4,6 +4,7 @@ import Field from "@/lib/components/ui/Field";
 import {
   BrainConfig,
   Model,
+  PaidModels,
   anthropicModels,
   models,
   paidModels,
@@ -12,7 +13,7 @@ import { UseFormRegister } from "react-hook-form";
 
 interface ModelConfigProps {
   register: UseFormRegister<BrainConfig>;
-  model: Model;
+  model: Model | PaidModels;
   openAiKey: string | undefined;
   temperature: number;
   maxTokens: number;
@@ -25,6 +26,24 @@ export const ModelConfig = ({
   temperature,
   maxTokens,
 }: ModelConfigProps): JSX.Element => {
+  const defineMaxTokens = (model: Model | PaidModels): number => {
+    //At the moment is evaluating only models from OpenAI
+    switch (model) {
+      case "gpt-3.5-turbo":
+        return 3000;
+      case "gpt-3.5-turbo-0613":
+        return 3000;
+      case "gpt-3.5-turbo-16k":
+        return 15000;
+      case "gpt-4":
+        return 6000;
+      case "gpt-4-0613":
+        return 6000;
+      default:
+        return 3000;
+    }
+  };
+
   return (
     <>
       <div className="border-b border-gray-300 mt-8 mb-8">
@@ -85,8 +104,8 @@ export const ModelConfig = ({
         <input
           type="range"
           min="256"
-          max="3000"
-          step="1"
+          max={defineMaxTokens(model)}
+          step="32"
           value={maxTokens}
           {...register("maxTokens")}
         />

--- a/frontend/lib/context/BrainConfigProvider/brain-config-provider.tsx
+++ b/frontend/lib/context/BrainConfigProvider/brain-config-provider.tsx
@@ -13,7 +13,7 @@ export const BrainConfigContext = createContext<ConfigContext | undefined>(
 );
 
 const defaultBrainConfig: BrainConfig = {
-  model: "gpt-3.5-turbo",
+  model: "gpt-3.5-turbo-0613",
   temperature: 0,
   maxTokens: 500,
   keepLocal: true,

--- a/frontend/lib/context/BrainConfigProvider/types.ts
+++ b/frontend/lib/context/BrainConfigProvider/types.ts
@@ -19,13 +19,9 @@ export type ConfigContext = {
 };
 
 // export const openAiModels = ["gpt-3.5-turbo", "gpt-4"] as const; ## TODO activate GPT4 when not in demo mode
-export const openAiModels = [   "gpt-3.5-turbo",
-    "gpt-3.5-turbo",
-    "gpt-3.5-turbo-0613",
-    "gpt-3.5-turbo-16k"] as const;
-    
-export const openAiPaidModels = ["gpt-4","gpt-4-0613"] as const;
 
+export const openAiModels = ["gpt-3.5-turbo","gpt-3.5-turbo-0613","gpt-3.5-turbo-16k"] as const;
+export const openAiPaidModels = ["gpt-3.5-turbo","gpt-3.5-turbo-0613","gpt-3.5-turbo-16k","gpt-4","gpt-4-0613"] as const;
 
 export const anthropicModels = [
   // "claude-v1",

--- a/frontend/lib/context/BrainConfigProvider/types.ts
+++ b/frontend/lib/context/BrainConfigProvider/types.ts
@@ -19,8 +19,16 @@ export type ConfigContext = {
 };
 
 // export const openAiModels = ["gpt-3.5-turbo", "gpt-4"] as const; ## TODO activate GPT4 when not in demo mode
-export const openAiModels = ["gpt-3.5-turbo"] as const;
-export const openAiPaidModels = ["gpt-3.5-turbo", "gpt-4"] as const;
+export const openAiModels = [   "gpt-3.5-turbo",
+    "gpt-3.5-turbo",
+    "gpt-3.5-turbo-0613",
+    "gpt-3.5-turbo-16k"] as const;
+    
+export const openAiPaidModels = [ "gpt-3.5-turbo",
+    "gpt-3.5-turbo-0613",
+    "gpt-3.5-turbo-16k",
+    "gpt-4",
+    "gpt-4-0613"] as const;
 
 export const anthropicModels = [
   // "claude-v1",

--- a/frontend/lib/context/BrainConfigProvider/types.ts
+++ b/frontend/lib/context/BrainConfigProvider/types.ts
@@ -24,11 +24,8 @@ export const openAiModels = [   "gpt-3.5-turbo",
     "gpt-3.5-turbo-0613",
     "gpt-3.5-turbo-16k"] as const;
     
-export const openAiPaidModels = [ "gpt-3.5-turbo",
-    "gpt-3.5-turbo-0613",
-    "gpt-3.5-turbo-16k",
-    "gpt-4",
-    "gpt-4-0613"] as const;
+export const openAiPaidModels = ["gpt-4","gpt-4-0613"] as const;
+
 
 export const anthropicModels = [
   // "claude-v1",


### PR DESCRIPTION
# Description

- Closes #332 

New OpenAI models were added: 

```
    "gpt-3.5-turbo-0613",
    "gpt-3.5-turbo-16k"
```

- Updated dropdown list to show new models. 
- Created a new function to control max token for each model, based on the model name. 
- Updated max token slider to step into 32 (arbitrary value, but better than 1) 


## Checklist before requesting a review

Please delete options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas
- [x] I have ideally added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

## Screenshots (if appropriate):

![image](https://github.com/StanGirard/quivr/assets/97035956/9c7d092b-cdaf-4889-8a48-2c3c64c43642)
