### PR TITLE
Update LICENSE link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ This project could not be possible without the support of our sponsors. Thank yo
 
 ## License 📄
 
-This project is licensed under the Apache 2.0 License - see the [LICENSE.md](LICENSE.md) file for details
+This project is licensed under the Apache 2.0 License - see the [LICENSE](LICENSE) file for details
 
 
 ## Stars History 📈


### PR DESCRIPTION
# Description

The license link in README points to a LICENSE.md file which doesn't exist anymore, but LICENSE does. Hence, updated the LICENSE link to point to the correct file.
