### PR TITLE
If .migration_info values are missing, prompt user for them

### DIFF
--- a/migration.sh
+++ b/migration.sh
@@ -6,17 +6,29 @@ run_sql_file() {
     PGPASSWORD=${DB_PASSWORD} psql -h "${DB_HOST}" -p "${DB_PORT}" -d "${DB_NAME}" -U "${DB_USER}" -f "$file"
 }
 
-# Check if .migration_info exists and source it, otherwise ask user for inputs
+# Flag to indicate whether to prompt for DB info
+prompt_for_db_info=false
+
+# Check if .migration_info exists and source it
 if [ -f .migration_info ]; then
     source .migration_info
+    # Check if any of the variables are empty
+    if [ -z "$DB_HOST" ] || [ -z "$DB_NAME" ] || [ -z "$DB_PORT" ] || [ -z "$DB_USER" ] || [ -z "$DB_PASSWORD" ]; then
+        prompt_for_db_info=true # Some values are empty, so prompt user for values
+    fi
 else
+    prompt_for_db_info=true # No .migration_info file, so prompt user for values
+fi
+
+# If .migration_info doesn't exist or any of the variables are empty, prompt for DB info
+if $prompt_for_db_info ; then
     echo "Please enter the following database connection information that can be found in Supabase in Settings -> database:"
     DB_HOST=$(gum input --placeholder "Host")
     DB_NAME=$(gum input --placeholder "Database name")
     DB_PORT=$(gum input --placeholder "Port")
     DB_USER=$(gum input --placeholder "User")
     DB_PASSWORD=$(gum input --placeholder "Password" --password)
-    
+
     # Save the inputs in .migration_info file
     echo "DB_HOST=$DB_HOST" > .migration_info
     echo "DB_NAME=$DB_NAME" >> .migration_info


### PR DESCRIPTION
# Description

**Context:** I couldn't get Quiver running locally using `install_helper.sh`. After some troubleshooting, it turned out that I had used the anon key for Supabase in place of the secret key, and so my initial install attempt was unsuccessful. Even when I fixed the keys, however, the migration scripts continually failed. It turned out this was because the `.migration_info` file was created on the initial attempt, but it had empty values. When the script sourced these values, nothing worked, as one might expect. 

**Problem:** `migration.sh` only checks for the existence of `.migration_info`, not whether the values are actually populated.

**Solution:** add a flag to indicate whether to prompt for DB info `prompt_for_db_info=false`, which becomes `true` if `.migration_info` does not exist OR if any of the necessary variables it contains are empty.

## Checklist before requesting a review

Please delete options that are not relevant.

- [x] I have commented hard-to-understand areas

## Screenshots (if appropriate):

If I set my `.migration_info` file to something like this (note the empty values):
```zsh
DB_HOST=db.mwknlvqugcaygrwob***
DB_NAME=postgres
DB_PORT=
DB_USER=postgres
DB_PASSWORD=
```
Then I get prompted appropriately by `gum` to fill in the values:

<img width="1031" alt="Screenshot 2023-07-13 at 8 59 56 AM" src="https://github.com/StanGirard/quivr/assets/19649268/3df8476d-4855-4f11-a6d4-46a0d621958d">