### PR TITLE
Fixed pandocs error on backend/Dockerfile.dev

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -9,6 +9,8 @@ COPY ./requirements.txt /code/requirements.txt
 
 RUN pip install --no-cache-dir -r /code/requirements.txt --timeout 100
 
+RUN apt-get install -y pandoc
+
 #You may need to run `chmod +x ./backend/scripts/start.sh` on your host machine if you get a permission error
 COPY ./scripts/start.sh /code/scripts/start.sh
 RUN chmod +x /code/scripts/start.sh

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,0 @@
-NEXT_PUBLIC_ENV=local
-BACKEND_URL="http://localhost:5050"


### PR DESCRIPTION
# Description

This PR resolves an issue where the application was unable to start due to the absence of `pandoc` in our Docker environment. The absence of `pandoc` was causing a crash upon startup. 

To address this, I've updated our Dockerfile to install `pandoc` during the Docker image creation process. Specifically, the `RUN apt-get install -y pandoc` command has been added after the `RUN apt-get update`.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

## Screenshots (if appropriate):

N/A