### PR TITLE
Fix: mobile can't click brain ico

### DIFF
--- a/frontend/lib/components/ui/Modal.tsx
+++ b/frontend/lib/components/ui/Modal.tsx
@@ -42,7 +42,7 @@ export const Modal = ({
           <Dialog.Portal forceMount>
             <Dialog.Overlay asChild forceMount>
               <motion.div
-                className="z-40 py-20 fixed inset-0 flex justify-center overflow-auto cursor-pointer bg-black/50 backdrop-blur-sm"
+                className="z-50 md:z-40 py-20 fixed inset-0 flex justify-center overflow-auto cursor-pointer bg-black/50 backdrop-blur-sm"
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}

--- a/frontend/lib/components/ui/Popover.tsx
+++ b/frontend/lib/components/ui/Popover.tsx
@@ -35,7 +35,7 @@ const Popover = ({
                 }}
                 exit={{ opacity: 0, y: -32 }}
                 transition={{ duration: 0.2, ease: "easeInOut" }}
-                className="relative flex flex-col p-4 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg shadow-lg z-40"
+                className="relative flex flex-col p-4 bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-lg shadow-lg z-50 md:z-40"
               >
                 <div className="flex-1">{children}</div>
                 <div className="mt-4 self-end flex gap-4">


### PR DESCRIPTION


Closes: #573 


# Description

Updated the `z-index` for mobile views,


Please delete options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas

## Screenshots (if appropriate):
<img width="511" alt="Screenshot 2023-07-18 at 7 22 54 PM" src="https://github.com/StanGirard/quivr/assets/49753983/3935f3c2-cc0a-44d9-9093-cece55981eff">

<img width="516" alt="Screenshot 2023-07-18 at 7 23 06 PM" src="https://github.com/StanGirard/quivr/assets/49753983/9d751850-5eca-4a0e-8149-bbc6e60d182d">

