### PR TITLE
Fix misspelled link to contributors page

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Additionally, you'll need a [Supabase](https://supabase.com/) account for:
 ## Contributors ✨
 
 Thanks go to these wonderful people:
-<a href="https://github.com/stangirard/quivr/graphs/ciontributors">
+<a href="https://github.com/stangirard/quivr/graphs/contributors">
 <img src="https://contrib.rocks/image?repo=stangirard/quivr" />
 </a>
 


### PR DESCRIPTION

Just a small edit to make for the main page to fix the link :)

Fix misspelled link (https://github.com/stangirard/quivr/graphs/ciontributors) to https://github.com/stangirard/quivr/graphs/contributors 
