### PR TITLE
fix(backend/brain): Allow overriding of `BrainRateLimiting`, implement `ProvideBrainRateLimit` for routes

### DIFF
--- a/backend/core/models/brains.py
+++ b/backend/core/models/brains.py
@@ -28,10 +28,6 @@ class Brain(BaseModel):
     def max_brain_size(self) -> int:
         return self.rate_limiting.max_brain_size
 
-    @max_brain_size.setter
-    def max_brain_size(self, value: int):
-        self.rate_limiting.max_brain_size = value
-
     @property
     def commons(self) -> CommonsDep:
         return common_dependencies()

--- a/backend/core/models/brains.py
+++ b/backend/core/models/brains.py
@@ -2,7 +2,7 @@ from typing import Any, List, Optional
 from uuid import UUID
 
 from logger import get_logger
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from utils.vectors import get_unique_files_from_vector_ids
 
 from models.settings import BrainRateLimiting, CommonsDep, common_dependencies
@@ -19,14 +19,14 @@ class Brain(BaseModel):
     temperature: Optional[float] = 0.0
     max_tokens: Optional[int] = 256
     files: List[Any] = []
+    rate_limiting: BrainRateLimiting = Field(default_factory=BrainRateLimiting)
 
     class Config:
         arbitrary_types_allowed = True
 
     @property
     def max_brain_size(self) -> int:
-        brain_rate_limiting = BrainRateLimiting()
-        return brain_rate_limiting.max_brain_size
+        return self.rate_limiting.max_brain_size
 
     @property
     def commons(self) -> CommonsDep:

--- a/backend/core/models/brains.py
+++ b/backend/core/models/brains.py
@@ -28,6 +28,10 @@ class Brain(BaseModel):
     def max_brain_size(self) -> int:
         return self.rate_limiting.max_brain_size
 
+    @max_brain_size.setter
+    def max_brain_size(self, value: int):
+        self.rate_limiting.max_brain_size = value
+
     @property
     def commons(self) -> CommonsDep:
         return common_dependencies()

--- a/backend/core/models/settings.py
+++ b/backend/core/models/settings.py
@@ -8,8 +8,8 @@ from vectorstore.supabase import SupabaseVectorStore
 
 
 class BrainRateLimiting(BaseSettings):
-    max_brain_size = 52428800
-    max_brain_per_user = 5
+    max_brain_size: int = 52428800
+    max_brain_per_user: int = 5
 
 
 class BrainSettings(BaseSettings):

--- a/backend/core/routes/brain_routes.py
+++ b/backend/core/routes/brain_routes.py
@@ -105,7 +105,8 @@ async def create_brain_endpoint(
     brain = Brain(name=brain.name)  # pyright: ignore reportPrivateUsage=none
 
     user_brains = brain.get_user_brains(current_user.id)
-    max_brain_per_user = BrainRateLimiting().max_brain_per_user
+    if (max_brain_per_user := brain.rate_limiting.max_brain_per_user) is None:
+        max_brain_per_user = BrainRateLimiting().max_brain_per_user
 
     if len(user_brains) >= max_brain_per_user:
         raise HTTPException(

--- a/backend/core/routes/crawl_routes.py
+++ b/backend/core/routes/crawl_routes.py
@@ -35,9 +35,9 @@ async def crawl_endpoint(
     commons = common_dependencies()
 
     if request.headers.get("Openai-Api-Key"):
-        brain.max_brain_size = os.getenv(
+        brain.max_brain_size = int(os.getenv(
             "MAX_BRAIN_SIZE_WITH_KEY", 209715200
-        )  # pyright: ignore reportPrivateUsage=none
+        ))
 
     file_size = 1000000
     remaining_free_space = brain.remaining_brain_size

--- a/backend/core/routes/upload_routes.py
+++ b/backend/core/routes/upload_routes.py
@@ -46,9 +46,9 @@ async def upload_file(
     commons = common_dependencies()
 
     if request.headers.get("Openai-Api-Key"):
-        brain.max_brain_size = os.getenv(
+        brain.max_brain_size = int(os.getenv(
             "MAX_BRAIN_SIZE_WITH_KEY", 209715200
-        )  # pyright: ignore reportPrivateUsage=none
+        ))
     remaining_free_space = brain.remaining_brain_size
 
     file_size = get_file_size(uploadFile)


### PR DESCRIPTION
# Description

- The `BrainRateLimiting` class now explicitly defines the types of `max_brain_size` and `max_brain_per_user` as integers.
- The `Brain` class now includes a `rate_limiting` field of type `BrainRateLimiting` with a default instance of the class. This replaces the previous approach of creating a new instance of `BrainRateLimiting` every time `max_brain_size` was accessed.


Originally, this PR implemented a setter for `Brain.max_brain_size`, but pydantic versions below v2 don't actually support property.fset (without some hackarounds) (see: https://github.com/pydantic/pydantic#935).

So instead, I've updated it to add a provider for brain rate limit that sets the appropriate rate limit if an openai key is provided and updates the routes to reflect this.


Resolves #734

## Checklist before requesting a review

Please delete options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas
- [x] I have ideally added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged
