### PR TITLE
fix(backend): FastAPI docs broken due to missing schema for `NullableUUID`

### DIFF
--- a/backend/core/routes/chat_routes.py
+++ b/backend/core/routes/chat_routes.py
@@ -28,13 +28,14 @@ from utils.constants import (
 chat_router = APIRouter()
 
 
-class NullableUUID:
+class NullableUUID(UUID):
+
     @classmethod
     def __get_validators__(cls):
         yield cls.validate
 
     @classmethod
-    def validate(cls, v):
+    def validate(cls, v) -> UUID | None:
         if v == "":
             return None
         try:


### PR DESCRIPTION
Just updates `NullableUUID` to extend from `UUID`. This lets FastAPI infer the correct field schema and resolves the /docs and /redocs endpoint failing to render

# Description

Just updates `NullableUUID` to extend from `UUID`. This lets FastAPI infer the correct field schema and resolves the /docs and /redocs endpoint failing to render

## Checklist before requesting a review

Please delete options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas
- [x] I have ideally added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

