### PR TITLE
Fix: Toast message hidden under the footer

### DIFF
--- a/frontend/lib/components/ui/Toast/components/Toast.tsx
+++ b/frontend/lib/components/ui/Toast/components/Toast.tsx
@@ -60,7 +60,7 @@ export const Toast = ({
             );
           })}
         </AnimatePresence>
-        <ToastPrimitive.Viewport className="fixed flex-col bottom-0 left-0 right-0 p-5 flex items-end gap-2 outline-none pointer-events-none" />
+        <ToastPrimitive.Viewport className="fixed flex-col bottom-0 left-0 right-0 p-5 flex items-end gap-2 outline-none pointer-events-none z-20" />
       </ToastContext.Provider>
     </ToastPrimitive.Provider>
   );


### PR DESCRIPTION

Closes: #702 

## Screenshots (if appropriate):
<img width="513" alt="Screenshot 2023-07-25 at 10 58 16 AM" src="https://github.com/StanGirard/quivr/assets/49753983/9be35118-3dac-4330-98e5-6aede8d570a6">
