### PR TITLE
fix(frontend): correctly display document information in explore view details

### DIFF
--- a/frontend/app/explore/DocumentItem/DocumentData.tsx
+++ b/frontend/app/explore/DocumentItem/DocumentData.tsx
@@ -50,10 +50,10 @@ const DocumentData = ({ documentName }: DocumentDataProps): JSX.Element => {
                   {key.replaceAll("_", " ")}
                 </p>
                 <span className="break-words my-auto">
-                  {typeof value === "object" ? (
+                  {value && typeof value === "object" ? (
                     <pre>{JSON.stringify(value, undefined, 2)}</pre>
                   ) : (
-                    String(value) || "Not Available"
+                    String(value || "Not Available")
                   )}
                 </span>
               </div>

--- a/frontend/app/explore/DocumentItem/DocumentData.tsx
+++ b/frontend/app/explore/DocumentItem/DocumentData.tsx
@@ -46,9 +46,15 @@ const DocumentData = ({ documentName }: DocumentDataProps): JSX.Element => {
           Object.entries(documents[0]).map(([key, value]) => {
             return (
               <div className="grid grid-cols-2 py-2 border-b" key={key}>
-                <p className="capitalize font-bold break-words">{key.replaceAll('_', ' ')}</p>
+                <p className="capitalize font-bold break-words">
+                  {key.replaceAll("_", " ")}
+                </p>
                 <span className="break-words my-auto">
-                  {typeof value === 'object' ? (<pre>{JSON.stringify(value, undefined, 2)}</pre>) : String(value) || 'Not Available'}
+                  {typeof value === "object" ? (
+                    <pre>{JSON.stringify(value, undefined, 2)}</pre>
+                  ) : (
+                    String(value) || "Not Available"
+                  )}
                 </span>
               </div>
             );

--- a/frontend/app/explore/DocumentItem/DocumentData.tsx
+++ b/frontend/app/explore/DocumentItem/DocumentData.tsx
@@ -44,17 +44,14 @@ const DocumentData = ({ documentName }: DocumentDataProps): JSX.Element => {
       <div className="flex flex-col">
         {documents[0] &&
           Object.entries(documents[0]).map(([key, value]) => {
+            if (value && typeof value === "object") return;
             return (
               <div className="grid grid-cols-2 py-2 border-b" key={key}>
                 <p className="capitalize font-bold break-words">
                   {key.replaceAll("_", " ")}
                 </p>
                 <span className="break-words my-auto">
-                  {value && typeof value === "object" ? (
-                    <pre>{JSON.stringify(value, undefined, 2)}</pre>
-                  ) : (
-                    String(value || "Not Available")
-                  )}
+                  {String(value || "Not Available")}
                 </span>
               </div>
             );

--- a/frontend/app/explore/DocumentItem/DocumentData.tsx
+++ b/frontend/app/explore/DocumentItem/DocumentData.tsx
@@ -43,14 +43,12 @@ const DocumentData = ({ documentName }: DocumentDataProps): JSX.Element => {
 
       <div className="flex flex-col">
         {documents[0] &&
-          Object.keys(documents[0]).map((doc) => {
+          Object.entries(documents[0]).map(([key, value]) => {
             return (
-              <div className="grid grid-cols-2 py-2 border-b" key={doc}>
-                <p className="capitalize font-bold break-words">
-                  {doc.replaceAll("_", " ")}
-                </p>
+              <div className="grid grid-cols-2 py-2 border-b" key={key}>
+                <p className="capitalize font-bold break-words">{key.replaceAll('_', ' ')}</p>
                 <span className="break-words my-auto">
-                  {documents[0][doc] || "Not Available"}
+                  {typeof value === 'object' ? (<pre>{JSON.stringify(value, undefined, 2)}</pre>) : String(value) || 'Not Available'}
                 </span>
               </div>
             );

--- a/frontend/app/explore/DocumentItem/__tests__/DocumentData.test.tsx
+++ b/frontend/app/explore/DocumentItem/__tests__/DocumentData.test.tsx
@@ -1,4 +1,4 @@
-import { render, waitFor } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { BrainConfigProvider } from "@/lib/context/BrainConfigProvider";
@@ -62,18 +62,18 @@ vi.mock("@/lib/hooks", async () => {
 describe("DocumentData", () => {
   it("should render document data", async () => {
     const documentName = "Test document";
-    const { getByText } = render(
+    render(
       <BrainConfigProvider>
         <DocumentData documentName={documentName} />
       </BrainConfigProvider>
     );
 
-    expect(getByText(documentName)).toBeDefined();
+    expect(screen.getByText(documentName)).toBeDefined();
 
     await waitFor(() => {
-      expect(getByText("mock_vector_id_1")).toBeDefined();
-      // TODO: second vector is not rendered
-      // expect(getByText('mock_vector_id_2')).toBeDefined()
+      expect(screen.getByText("content")).toBeDefined();
+      expect(screen.getByText("foo,bar", { exact: false })).toBeDefined();
+      expect(screen.getByText("baz,bat", { exact: false })).toBeDefined();
     });
   });
 });

--- a/frontend/app/explore/DocumentItem/__tests__/DocumentData.test.tsx
+++ b/frontend/app/explore/DocumentItem/__tests__/DocumentData.test.tsx
@@ -1,8 +1,6 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-
 import { BrainConfigProvider } from "@/lib/context/BrainConfigProvider";
-
 import DocumentData from "../DocumentData";
 
 const useSupabaseMock = vi.fn(() => ({

--- a/frontend/app/explore/DocumentItem/__tests__/DocumentData.test.tsx
+++ b/frontend/app/explore/DocumentItem/__tests__/DocumentData.test.tsx
@@ -1,0 +1,76 @@
+import { render, waitFor } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { BrainConfigProvider } from '@/lib/context/BrainConfigProvider'
+
+import DocumentData from '../DocumentData'
+
+const useSupabaseMock = vi.fn(() => ({
+  session: { user: {} },
+}))
+
+vi.mock('@/lib/context/SupabaseProvider', () => ({
+  useSupabase: () => useSupabaseMock(),
+}))
+
+vi.mock('@/lib/hooks', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/hooks')>('@/lib/hooks')
+
+  return {
+    ...actual,
+    useAxios: () => ({
+      axiosInstance: {
+        get: vi.fn().mockResolvedValue({
+          data: {
+            documents: [
+              {
+                file_name: 'mock_file_name.pdf',
+                file_size: '0',
+                file_extension: null,
+                file_url: null,
+                content: 'foo,bar\nbaz,bat',
+                brains_vectors: [
+                  {
+                    brain_id: 'mock_brain_id',
+                    vector_id: 'mock_vector_id_1',
+                  },
+                ],
+              },
+              {
+                file_name: 'mock_file_name.pdf',
+                file_size: '0',
+                file_extension: null,
+                file_url: null,
+                content: 'foo,bar\nbaz,bat',
+                brains_vectors: [
+                  {
+                    brain_id: 'mock_brain_id',
+                    vector_id: 'mock_vector_id_2',
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      },
+    }),
+  }
+})
+
+describe('DocumentData', () => {
+  it('should render document data', async () => {
+    const documentName = 'Test document'
+    const { getByText } = render(
+      <BrainConfigProvider>
+        <DocumentData documentName={documentName} />
+      </BrainConfigProvider>
+    )
+
+    expect(getByText(documentName)).toBeDefined()
+
+    await waitFor(() => {
+      expect(getByText('mock_vector_id_1')).toBeDefined()
+      expect(getByText('mock_vector_id_2')).toBeDefined()
+    })
+  })
+})

--- a/frontend/app/explore/DocumentItem/__tests__/DocumentData.test.tsx
+++ b/frontend/app/explore/DocumentItem/__tests__/DocumentData.test.tsx
@@ -1,20 +1,22 @@
-import { render, waitFor } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { render, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
-import { BrainConfigProvider } from '@/lib/context/BrainConfigProvider'
+import { BrainConfigProvider } from "@/lib/context/BrainConfigProvider";
 
-import DocumentData from '../DocumentData'
+import DocumentData from "../DocumentData";
 
 const useSupabaseMock = vi.fn(() => ({
   session: { user: {} },
-}))
+}));
 
-vi.mock('@/lib/context/SupabaseProvider', () => ({
+vi.mock("@/lib/context/SupabaseProvider", () => ({
   useSupabase: () => useSupabaseMock(),
-}))
+}));
 
-vi.mock('@/lib/hooks', async () => {
-  const actual = await vi.importActual<typeof import('@/lib/hooks')>('@/lib/hooks')
+vi.mock("@/lib/hooks", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/hooks")>(
+    "@/lib/hooks"
+  );
 
   return {
     ...actual,
@@ -24,28 +26,28 @@ vi.mock('@/lib/hooks', async () => {
           data: {
             documents: [
               {
-                file_name: 'mock_file_name.pdf',
-                file_size: '0',
+                file_name: "mock_file_name.pdf",
+                file_size: "0",
                 file_extension: null,
                 file_url: null,
-                content: 'foo,bar\nbaz,bat',
+                content: "foo,bar\nbaz,bat",
                 brains_vectors: [
                   {
-                    brain_id: 'mock_brain_id',
-                    vector_id: 'mock_vector_id_1',
+                    brain_id: "mock_brain_id",
+                    vector_id: "mock_vector_id_1",
                   },
                 ],
               },
               {
-                file_name: 'mock_file_name.pdf',
-                file_size: '0',
+                file_name: "mock_file_name.pdf",
+                file_size: "0",
                 file_extension: null,
                 file_url: null,
-                content: 'foo,bar\nbaz,bat',
+                content: "foo,bar\nbaz,bat",
                 brains_vectors: [
                   {
-                    brain_id: 'mock_brain_id',
-                    vector_id: 'mock_vector_id_2',
+                    brain_id: "mock_brain_id",
+                    vector_id: "mock_vector_id_2",
                   },
                 ],
               },
@@ -54,23 +56,24 @@ vi.mock('@/lib/hooks', async () => {
         }),
       },
     }),
-  }
-})
+  };
+});
 
-describe('DocumentData', () => {
-  it('should render document data', async () => {
-    const documentName = 'Test document'
+describe("DocumentData", () => {
+  it("should render document data", async () => {
+    const documentName = "Test document";
     const { getByText } = render(
       <BrainConfigProvider>
         <DocumentData documentName={documentName} />
       </BrainConfigProvider>
-    )
+    );
 
-    expect(getByText(documentName)).toBeDefined()
+    expect(getByText(documentName)).toBeDefined();
 
     await waitFor(() => {
-      expect(getByText('mock_vector_id_1')).toBeDefined()
-      expect(getByText('mock_vector_id_2')).toBeDefined()
-    })
-  })
-})
+      expect(getByText("mock_vector_id_1")).toBeDefined();
+      // TODO: second vector is not rendered
+      // expect(getByText('mock_vector_id_2')).toBeDefined()
+    });
+  });
+});


### PR DESCRIPTION
# Description

React is unable to render an object as a React child. The component was iterating over a brain document's keys and values, and attempting to render the value. However, one of the document's keys, `brains_vectors`, is an array of objects, which is not a valid React child.

In this PR I check the value type before rendering, and skip rendering that value if it's defined and an object.

Closes https://github.com/StanGirard/quivr/issues/763.

## Checklist before requesting a review

Please delete options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have ideally added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if appropriate):

Before | After
--- | ---
<img width="1078" alt="image" src="https://github.com/StanGirard/quivr/assets/10081464/eafcfe2f-52e0-4db6-b136-50d0dc5e2f3b"> | <img width="513" alt="image" src="https://github.com/StanGirard/quivr/assets/10081464/ecab3d7d-afef-4783-81f5-17ffd6bf01f8">

