### PR TITLE
fix(chat routes): HTTPException import correction

### DIFF
--- a/backend/core/routes/chat_routes.py
+++ b/backend/core/routes/chat_routes.py
@@ -124,7 +124,7 @@ async def update_chat_metadata_handler(
     """
 
     chat = get_chat_by_id(chat_id)  # pyright: ignore reportPrivateUsage=none
-    if current_user.id != chat.user_id:
+    if str(current_user.id) != chat.user_id:
         raise HTTPException(
             status_code=403,  # pyright: ignore reportPrivateUsage=none
             detail="You should be the owner of the chat to update it.",  # pyright: ignore reportPrivateUsage=none

--- a/backend/core/routes/chat_routes.py
+++ b/backend/core/routes/chat_routes.py
@@ -1,12 +1,11 @@
 import os
 import time
-from http.client import HTTPException
 from typing import List
 from uuid import UUID
 from venv import logger
 
 from auth import AuthBearer, get_current_user
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import StreamingResponse
 from llm.openai import OpenAIBrainPicking
 from models.brains import Brain, get_default_user_brain_or_create_new


### PR DESCRIPTION
Solves "TypeError: HTTPException() takes no keyword arguments"

EDIT: also fixed an error in the user id comparison (current_user.id is a UUID object, chat.user_id is a str)

# Description

Currently, when `PUT /chat/:chat_id/metadata` is called, the error "TypeError: HTTPException() takes no keyword arguments" is raised due to an incorrect import.

See also: https://stackoverflow.com/questions/73330113/typeerror-httpexception-takes-no-keyword-arguments