### PR TITLE
feat (926): make crawl recursively navigate linked pages

### DIFF
--- a/backend/core/crawl/crawler.py
+++ b/backend/core/crawl/crawler.py
@@ -3,6 +3,7 @@ import re
 import tempfile
 import unicodedata
 
+from urllib.parse import  urljoin
 import requests
 from pydantic import BaseModel
 
@@ -10,7 +11,7 @@ from pydantic import BaseModel
 class CrawlWebsite(BaseModel):
     url: str
     js: bool = False
-    depth: int = 1
+    depth: int = int(os.getenv("CRAWL_DEPTH","1"))
     max_pages: int = 100
     max_time: int = 60
 
@@ -26,19 +27,43 @@ class CrawlWebsite(BaseModel):
             return None
 
     def process(self):
-        content = self._crawl(self.url)
+        visited_list=[]
+        self._process_level(self.url, 0, visited_list)
+        return visited_list
 
+    def _process_level(self, url, level_depth, visited_list):
+        content = self._crawl(url)
+        if content is None:
+            return
+        
+        
         # Create a file
-        file_name = slugify(self.url) + ".html"
+        file_name = slugify(url) + ".html"
         temp_file_path = os.path.join(tempfile.gettempdir(), file_name)
         with open(temp_file_path, "w") as temp_file:
             temp_file.write(content)  # pyright: ignore reportPrivateUsage=none
             # Process the file
 
         if content:
-            return temp_file_path, file_name
-        else:
-            return None
+            visited_list.append((temp_file_path, file_name))
+            from bs4 import BeautifulSoup
+            soup = BeautifulSoup(content, 'html5lib')
+            links = soup.findAll('a')
+            if level_depth < self.depth:
+                for a in links:
+                    if not a.has_attr('href'):
+                        continue
+                    new_url = a['href']
+                    file_name = slugify(new_url) + ".html"
+                    already_visited = False
+                    for (fpath,fname) in visited_list:
+                        if fname == file_name :
+                            already_visited = True
+                            break
+                    if not already_visited:
+                        self._process_level(urljoin(url,new_url),level_depth + 1,visited_list)
+
+
 
     def checkGithub(self):
         if "github.com" in self.url:

--- a/backend/core/requirements.txt
+++ b/backend/core/requirements.txt
@@ -24,3 +24,5 @@ pyright==1.1.316
 resend==0.5.1
 psycopg2-binary==2.9.6
 sqlalchemy==2.0.19
+html5lib==1.1
+bs4==0.0.1


### PR DESCRIPTION
# Description

Used existing process code, added logic to recursevely navigate linked pages. Not limiting to be the same domain or subdomain. Depth is defined in environment variable CRAWL_DEPTH. Maybe it should be specified in documentation.

## Checklist before requesting a review

Please delete options that are not relevant.

- [x ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my code
- [x ] I have commented hard-to-understand areas
- [x ] I have ideally added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x ] Any dependent changes have been merged

## Screenshots (if appropriate):
