### PR TITLE
Fixed backend .env file navigation

### DIFF
--- a/install_helper.sh
+++ b/install_helper.sh
@@ -47,7 +47,7 @@ if grep -q "SUPABASE_SERVICE_KEY=<change-me>" backend/core/.env; then
     replace_in_file backend/core/.env "SUPABASE_SERVICE_KEY=.*" "SUPABASE_SERVICE_KEY=${SUPABASE_SERVICE_KEY}"
 fi
 
-if grep -q "PG_DATABASE_URL=<change-me>" backend/.env; then
+if grep -q "PG_DATABASE_URL=<change-me>" backend/core/.env; then
     echo "PG_DATABASE_URL can be found in your Postgres provider Settings > API."
     PG_DATABASE_URL=$(gum input --placeholder "Enter PG_DATABASE_URL for backend")
     replace_in_file backend/.env "PG_DATABASE_URL=.*" "PG_DATABASE_URL=${PG_DATABASE_URL}"


### PR DESCRIPTION
# Description

Upon running `./install_helper.sh`, `backend/.env` couldn't be found because it's not existant.
I fixed it by adding the `core` folder.
It's now `backend/core/.env`

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] New and existing unit tests pass locally with my changes

