### PR TITLE
feat(brain): add endpoint to return context to question

### DIFF
--- a/backend/models/databases/supabase/brains.py
+++ b/backend/models/databases/supabase/brains.py
@@ -43,6 +43,10 @@ class BrainUpdatableProperties(BaseModel):
         return brain_dict
 
 
+class BrainQuestionRequest(BaseModel):
+    question: str
+
+
 class Brain(Repository):
     def __init__(self, supabase_client):
         self.db = supabase_client

--- a/backend/repository/brain/__init__.py
+++ b/backend/repository/brain/__init__.py
@@ -10,3 +10,4 @@ from .update_user_rights import update_brain_user_rights
 from .get_default_user_brain import get_user_default_brain
 from .set_as_default_brain_for_user import set_as_default_brain_for_user
 from .get_default_user_brain_or_create_new import get_default_user_brain_or_create_new
+from .get_question_context_from_brain import get_question_context_from_brain

--- a/backend/repository/brain/get_question_context_from_brain.py
+++ b/backend/repository/brain/get_question_context_from_brain.py
@@ -1,0 +1,20 @@
+from uuid import UUID
+
+from models.settings import get_embeddings, get_supabase_client
+from vectorstore.supabase import CustomSupabaseVectorStore
+
+
+def get_question_context_from_brain(brain_id: UUID, question: str) -> str:
+    supabase_client = get_supabase_client()
+    embeddings = get_embeddings()
+
+    vector_store = CustomSupabaseVectorStore(
+        supabase_client,
+        embeddings,
+        table_name="vectors",
+        brain_id=brain_id,
+    )
+    documents = vector_store.similarity_search(question)
+
+    # aggregate all the documents into one string
+    return "\n".join([doc.page_content for doc in documents])


### PR DESCRIPTION
# Description

- Add endpoint for getting context to a question from brain.
- The endpoint can be used by 3rd party app that does not want to get LLM answer, but instead just want to get the vector store search result for a query.
  - Example: RealChar using it here https://github.com/Shaunwei/RealChar/pull/406

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes

## Screenshots (if appropriate):
<img width="2560" alt="image" src="https://github.com/StanGirard/quivr/assets/1465499/66ede22e-f992-4287-b44c-d72417f792b5">

