### PR TITLE
feat: handle new chat button click

### DIFF
--- a/frontend/app/chat/[chatId]/__tests__/page.test.tsx
+++ b/frontend/app/chat/[chatId]/__tests__/page.test.tsx
@@ -25,6 +25,11 @@ vi.mock("@/lib/context/ChatProvider/ChatProvider", () => ({
   ChatProvider: ChatProviderMock,
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useParams: () => ({ chatId: "1" }),
+}));
+
 vi.mock("@/lib/context/SupabaseProvider/supabase-provider", () => ({
   SupabaseContext: SupabaseContextMock,
 }));

--- a/frontend/app/chat/[chatId]/hooks/useChat.ts
+++ b/frontend/app/chat/[chatId]/hooks/useChat.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines */
 import { AxiosError } from "axios";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -22,7 +22,7 @@ export const useChat = () => {
     params?.chatId as string | undefined
   );
   const [generatingAnswer, setGeneratingAnswer] = useState(false);
-
+  const router = useRouter();
   const { history } = useChatContext();
   const { currentBrain, currentPromptId, currentBrainId } = useBrainContext();
   const { publish } = useToast();
@@ -46,12 +46,15 @@ export const useChat = () => {
 
       let currentChatId = chatId;
 
+      let shouldUpdateUrl = false;
+
       //if chatId is not set, create a new chat. Chat name is from the first question
       if (currentChatId === undefined) {
         const chatName = question.split(" ").slice(0, 3).join(" ");
         const chat = await createChat(chatName);
         currentChatId = chat.chat_id;
         setChatId(currentChatId);
+        shouldUpdateUrl = true;
         //TODO: update chat list here
       }
 
@@ -74,6 +77,10 @@ export const useChat = () => {
       await addStreamQuestion(currentChatId, chatQuestion);
 
       callback?.();
+
+      if (shouldUpdateUrl) {
+        router.replace(`/chat/${currentChatId}`);
+      }
     } catch (error) {
       console.error({ error });
 

--- a/frontend/app/chat/components/ChatsList/components/NewChatButton.tsx
+++ b/frontend/app/chat/components/ChatsList/components/NewChatButton.tsx
@@ -1,18 +1,18 @@
 import Link from "next/link";
-import { useTranslation } from 'react-i18next'
+import { useTranslation } from "react-i18next";
 import { BsPlusSquare } from "react-icons/bs";
 
+const newChatRoute = "/chat";
 export const NewChatButton = (): JSX.Element => {
   const { t } = useTranslation();
 
   return (
     <Link
-      href="/chat"
+      href={newChatRoute}
       data-testid="new-chat-button"
       className="px-4 py-2 mx-4 my-1 border border-primary bg-white dark:bg-black hover:text-white hover:bg-primary shadow-lg rounded-lg flex items-center justify-center top-1 z-20"
     >
-      <BsPlusSquare className="h-6 w-6 mr-2" /> {t('newChatButton')}
+      <BsPlusSquare className="h-6 w-6 mr-2" /> {t("newChatButton")}
     </Link>
   );
-}
-
+};


### PR DESCRIPTION
# Description

- When a user is on `/chat/xxx-xxx-xx-xxx` and clicks on the `New Chat` button, they are redirected to `/chat/`.
- However, when the user is on `/chat/` and then clicks on the `New Chat` button, nothing happens because the current page is already the destination page. To fix this, I reload the page in this case.