### PR TITLE
make docker compose command more flexible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+docker-compose.override.yml
 secondbrain/
 .env
 .streamlit/secrets.toml

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Additionally, you'll need a [Supabase](https://supabase.com/) account for:
 - **Step 5**: Launch the app
 
   ```bash
-  docker compose -f docker-compose.yml up --build
+  docker compose up --build
   ```
 
 - **Step 6**: Navigate to `localhost:3000` in your browser

--- a/docs/docs/get_started/intro.md
+++ b/docs/docs/get_started/intro.md
@@ -111,7 +111,7 @@ All the scripts can be found in the [scripts](https://github.com/stangirard/quiv
 - **Step 5**: Launch the app
 
 ```bash
-docker compose -f docker-compose.yml up --build
+docker compose up --build
 ```
 
 - **Step 6**: Navigate to `localhost:3000` in your browser

--- a/install_helper.sh
+++ b/install_helper.sh
@@ -80,7 +80,7 @@ echo "Running the migration scripts..."
 
 # Step 5: Launch the app
 echo "Launching the app..."
-docker compose -f docker-compose.yml up --build
+docker compose up --build
 
 # Final message
 echo "Navigate to localhost:3000 in your browser to access the app."


### PR DESCRIPTION
By not specifying `-f docker-compose.yml` in the docker compose command, it allows more flexible use of configuration files. `docker-compose.yml` is already the default config file when none is specified, and this also allows overrides via `docker-compose.override.yml`, which is recognized by default.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Checklist before requesting a review

Please delete options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas
- [x] I have ideally added tests that prove my fix is effective or that my feature works -- N/A
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

## Screenshots (if appropriate):
