### PR TITLE
fix(Select): fix JSX typo

### DIFF
--- a/frontend/lib/components/ui/Select.tsx
+++ b/frontend/lib/components/ui/Select.tsx
@@ -96,7 +96,7 @@ export const Select = <T extends string | number>({
                   <path
                     fill-rule="evenodd"
                     d="M10 3a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L10 4.852 7.3 7.76a.75.75 0 01-1.1-1.02l3.25-3.5A.75.75 0 0110 3zm-3.76 9.2a.75.75 0 011.06.04l2.7 2.908 2.7-2.908a.75.75 0 111.1 1.02l-3.25 3.5a.75.75 0 01-1.1 0l-3.25-3.5a.75.75 0 01.04-1.06z"
-                    clip-rule="evenodd"
+                    clipRule="evenodd"
                   />
                 </svg>
               </span>

--- a/frontend/lib/components/ui/Select.tsx
+++ b/frontend/lib/components/ui/Select.tsx
@@ -94,7 +94,7 @@ export const Select = <T extends string | number>({
                   aria-hidden="true"
                 >
                   <path
-                    fill-rule="evenodd"
+                    fillRule="evenodd"
                     d="M10 3a.75.75 0 01.55.24l3.25 3.5a.75.75 0 11-1.1 1.02L10 4.852 7.3 7.76a.75.75 0 01-1.1-1.02l3.25-3.5A.75.75 0 0110 3zm-3.76 9.2a.75.75 0 011.06.04l2.7 2.908 2.7-2.908a.75.75 0 111.1 1.02l-3.25 3.5a.75.75 0 01-1.1 0l-3.25-3.5a.75.75 0 01.04-1.06z"
                     clipRule="evenodd"
                   />


### PR DESCRIPTION
# Description

React prefers camelCase for `svg` attributes. There was a `console.warning` being thrown in the `Select.tsx` component.
## Checklist before requesting a review

Please delete options that are not relevant.

- [x] I have performed a self-review of my code

## Screenshots (if appropriate):
<img width="394" alt="Screenshot 2023-10-01 at 9 32 45 AM" src="https://github.com/StanGirard/quivr/assets/64866427/d16979ac-8a2e-4873-96ab-c92b2f093465">

<img width="380" alt="Screenshot 2023-10-01 at 9 32 54 AM" src="https://github.com/StanGirard/quivr/assets/64866427/9b4a8e57-9d79-4df5-ba40-7d80c00aee44">
