### PR TITLE
fix: prevent fetch when user is not logged in

### DIFF
--- a/frontend/app/App.tsx
+++ b/frontend/app/App.tsx
@@ -22,10 +22,12 @@ export const App = ({ children }: PropsWithChildren): JSX.Element => {
   usePageTracking();
 
   useEffect(() => {
-    void fetchAllBrains();
-    void fetchDefaultBrain();
-    void fetchPublicPrompts();
-  }, [session?.user.id]);
+    if (session?.user) {
+      void fetchAllBrains();
+      void fetchDefaultBrain();
+      void fetchPublicPrompts();
+    }
+  }, [session]);
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
# Description

When a user is logged out, it will try to fetch data and throw uncaught authentication errors in the console. This fix will only fetch if a user session exists.

## Checklist before requesting a review

Please delete options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented hard-to-understand areas
- [ ] I have ideally added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

## Screenshots (if appropriate):

<img width="506" alt="Screenshot 2023-10-01 at 6 48 57 PM" src="https://github.com/StanGirard/quivr/assets/64866427/bd962801-727e-4749-b9a8-8fb6711d93e3">

