### PR TITLE
fix: 🐛 Sidebar content should not hide the sidebar footer

### DIFF
--- a/frontend/lib/components/Sidebar/Sidebar.tsx
+++ b/frontend/lib/components/Sidebar/Sidebar.tsx
@@ -67,7 +67,7 @@ export const Sidebar = ({
           data-testid="sidebar"
         >
           <SidebarHeader setOpen={setOpen} />
-          {children}
+          <div className="overflow-auto flex flex-col flex-1">{children}</div>
           {showFooter && <SidebarFooter />}
         </motion.div>
       </motion.div>


### PR DESCRIPTION
# Description

Fixes the issue where the sidebar footer is not visible if the content is too long (like a too large chat history).

## Screenshots

Before (we cannot see the footer) :
<img width="271" alt="image" src="https://github.com/StanGirard/quivr/assets/67386567/2598d7f3-525c-4b59-8293-6833ef7562a9">

After (we can see it and scroll through the content):
<img width="271" alt="image" src="https://github.com/StanGirard/quivr/assets/67386567/69860c67-47e8-446a-962f-587b8549fe58">

