### PR TITLE
refactor: ♻️ ContentSecurityPolicy as an object

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -59,13 +59,13 @@ const ContentSecurityPolicy = {
 
 const cspString = Object.entries(ContentSecurityPolicy)
   .map(([key, values]) => `${key} ${values.join(" ")};`)
-  .join("\n");
+  .join(" ");
 
 // Define headers
 const securityHeaders = [
   {
     key: "Content-Security-Policy",
-    value: cspString.replace(/\n/g, ""),
+    value: cspString,
   },
   {
     key: "Referrer-Policy",

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -22,21 +22,50 @@ const nextConfig = {
   },
 };
 
-const ContentSecurityPolicy = `
-  default-src 'self' https://fonts.googleapis.com ${process.env.NEXT_PUBLIC_SUPABASE_URL} https://api.june.so https://www.quivr.app/; 
-  connect-src 'self' ${process.env.NEXT_PUBLIC_SUPABASE_URL} ${process.env.NEXT_PUBLIC_BACKEND_URL} https://api.june.so https://api.openai.com https://cdn.growthbook.io https://vitals.vercel-insights.com/v1/vitals;
-  img-src 'self' https://www.gravatar.com data:;
-  media-src 'self' https://user-images.githubusercontent.com https://www.quivr.app/ https://quivr-cms.s3.eu-west-3.amazonaws.com;
-  script-src 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com/  https://www.quivr.app/ https://www.google-analytics.com/;
-  frame-ancestors 'none';
-  style-src 'unsafe-inline' https://www.quivr.app/;
-`;
+const ContentSecurityPolicy = {
+  "default-src": [
+    "'self'",
+    "https://fonts.googleapis.com",
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    "https://api.june.so",
+    "https://www.quivr.app/",
+  ],
+  "connect-src": [
+    "'self'",
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_BACKEND_URL,
+    "https://api.june.so",
+    "https://api.openai.com",
+    "https://cdn.growthbook.io",
+    "https://vitals.vercel-insights.com/v1/vitals",
+  ],
+  "img-src": ["'self'", "https://www.gravatar.com", "data:"],
+  "media-src": [
+    "'self'",
+    "https://user-images.githubusercontent.com",
+    "https://www.quivr.app/",
+    "https://quivr-cms.s3.eu-west-3.amazonaws.com",
+  ],
+  "script-src": [
+    "'unsafe-inline'",
+    "'unsafe-eval'",
+    "https://va.vercel-scripts.com/",
+    "https://www.quivr.app/",
+    "https://www.google-analytics.com/",
+  ],
+  "frame-ancestors": ["'none'"],
+  "style-src": ["'unsafe-inline'", "https://www.quivr.app/"],
+};
+
+const cspString = Object.entries(ContentSecurityPolicy)
+  .map(([key, values]) => `${key} ${values.join(" ")};`)
+  .join("\n");
 
 // Define headers
 const securityHeaders = [
   {
     key: "Content-Security-Policy",
-    value: ContentSecurityPolicy.replace(/\n/g, ""),
+    value: cspString.replace(/\n/g, ""),
   },
   {
     key: "Referrer-Policy",


### PR DESCRIPTION
# Description

Improve developper experience with CSP by turning the csp into object instead of a large string.

## Developped in TDD with the following test

```ts
import { describe, expect } from "vitest";
process.env.NEXT_PUBLIC_SUPABASE_URL = "XXX";
process.env.NEXT_PUBLIC_BACKEND_URL = "YYY";

const OldContentSecurityPolicy =
  `default-src 'self' https://fonts.googleapis.com ${process.env.NEXT_PUBLIC_SUPABASE_URL} https://api.june.so https://www.quivr.app/;
 connect-src 'self' ${process.env.NEXT_PUBLIC_SUPABASE_URL} ${process.env.NEXT_PUBLIC_BACKEND_URL} https://api.june.so https://api.openai.com https://cdn.growthbook.io https://vitals.vercel-insights.com/v1/vitals;
 img-src 'self' https://www.gravatar.com data:;
 media-src 'self' https://user-images.githubusercontent.com https://www.quivr.app/ https://quivr-cms.s3.eu-west-3.amazonaws.com;
 script-src 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com/ https://www.quivr.app/ https://www.google-analytics.com/;
 frame-ancestors 'none';
 style-src 'unsafe-inline' https://www.quivr.app/;`.replace(/\n/g, "");

const ContentSecurityPolicy = {
  "default-src": [
    "'self'",
    "https://fonts.googleapis.com",
    process.env.NEXT_PUBLIC_SUPABASE_URL,
    "https://api.june.so",
    "https://www.quivr.app/",
  ],
  "connect-src": [
    "'self'",
    process.env.NEXT_PUBLIC_SUPABASE_URL,
    process.env.NEXT_PUBLIC_BACKEND_URL,
    "https://api.june.so",
    "https://api.openai.com",
    "https://cdn.growthbook.io",
    "https://vitals.vercel-insights.com/v1/vitals",
  ],
  "img-src": ["'self'", "https://www.gravatar.com", "data:"],
  "media-src": [
    "'self'",
    "https://user-images.githubusercontent.com",
    "https://www.quivr.app/",
    "https://quivr-cms.s3.eu-west-3.amazonaws.com",
  ],
  "script-src": [
    "'unsafe-inline'",
    "'unsafe-eval'",
    "https://va.vercel-scripts.com/",
    "https://www.quivr.app/",
    "https://www.google-analytics.com/",
  ],
  "frame-ancestors": ["'none'"],
  "style-src": ["'unsafe-inline'", "https://www.quivr.app/"],
};

const cspString = Object.entries(ContentSecurityPolicy)
  .map(([key, values]) => `${key} ${values.join(" ")};`)
  .join(" ");

describe("Test Csp", () => {
  expect(cspString).toEqual(OldContentSecurityPolicy);
});
```

## External checks

Syntax validity checked with : https://csp-evaluator.withgoogle.com/