### PR TITLE
fix: replace next/image's layout deprecated attribute

### DIFF
--- a/frontend/lib/components/Sidebar/components/SidebarFooter/components/UserButton.tsx
+++ b/frontend/lib/components/Sidebar/components/SidebarFooter/components/UserButton.tsx
@@ -15,7 +15,7 @@ export const UserButton = (): JSX.Element => {
       <div className="relative w-8 h-8">
         <Image
           alt="gravatar"
-          layout="fill"
+          fill={true}
           src={gravatarUrl}
           className="rounded-xl"
         />


### PR DESCRIPTION
# Description

In nextjs version 13, the `layout` attribute is deprecated in the `Image`.
Hence we had the following warning:

```
Image with src "https://www.gravatar.com/avatar/hash?d=mp" has legacy prop "layout". Did you forget to run the codemod?
Read more: https://nextjs.org/docs/messages/next-image-upgrade-to-13
```

## Solution

The fill attribute is not deprecated and plays the same role. (see the doc for the current props of Image : https://nextjs.org/docs/pages/api-reference/components/image)