### PR TITLE
feat: restructure the sidebar of the brains management page

### DIFF
--- a/frontend/app/brains-management/[brainId]/components/BrainsList/BrainsList.tsx
+++ b/frontend/app/brains-management/[brainId]/components/BrainsList/BrainsList.tsx
@@ -17,7 +17,7 @@ export const BrainsList = (): JSX.Element => {
   const { t } = useTranslation("brain");
 
   return (
-    <Sidebar showFooter={false}>
+    <Sidebar showButtons={['user']}>
       <div className="flex flex-col flex-1">
         <BrainSearchBar
           searchQuery={searchQuery}

--- a/frontend/app/chat/components/ChatsList/index.tsx
+++ b/frontend/app/chat/components/ChatsList/index.tsx
@@ -12,7 +12,7 @@ export const ChatsList = (): JSX.Element => {
   useChatNotificationsSync();
 
   return (
-    <Sidebar showFooter={true}>
+    <Sidebar showButtons={['myBrains', 'user']}>
       <div className="flex flex-col flex-1 h-full" data-testid="chats-list">
         <div className="pt-2">
           <NewChatButton />

--- a/frontend/lib/components/Sidebar/Sidebar.tsx
+++ b/frontend/lib/components/Sidebar/Sidebar.tsx
@@ -7,16 +7,17 @@ import { SidebarHeader } from "@/lib/components/Sidebar/components/SidebarHeader
 import { useDevice } from "@/lib/hooks/useDevice";
 import { cn } from "@/lib/utils";
 
-import { SidebarFooter } from "./components/SidebarFooter/SidebarFooter";
+import { SidebarFooter, SidebarFooterButtons } from "./components/SidebarFooter/SidebarFooter";
+
 
 type SidebarProps = {
   children: React.ReactNode;
-  showFooter: boolean;
+  showButtons: SidebarFooterButtons[];
 };
 
 export const Sidebar = ({
   children,
-  showFooter,
+  showButtons,
 }: SidebarProps): JSX.Element => {
   const { isMobile } = useDevice();
   const pathname = usePathname();
@@ -68,7 +69,7 @@ export const Sidebar = ({
         >
           <SidebarHeader setOpen={setOpen} />
           <div className="overflow-auto flex flex-col flex-1">{children}</div>
-          {showFooter && <SidebarFooter />}
+          <SidebarFooter showButtons={showButtons} />
         </motion.div>
       </motion.div>
     </MotionConfig>

--- a/frontend/lib/components/Sidebar/components/SidebarFooter/SidebarFooter.tsx
+++ b/frontend/lib/components/Sidebar/components/SidebarFooter/SidebarFooter.tsx
@@ -2,12 +2,18 @@ import { BrainManagementButton } from "@/lib/components/Sidebar/components/Sideb
 
 import { UserButton } from "./components/UserButton";
 
-export const SidebarFooter = (): JSX.Element => {
+export type SidebarFooterButtons = "myBrains" | "user";
+
+type SidebarFooterProps = {
+  showButtons: SidebarFooterButtons[];
+};
+
+export const SidebarFooter = ({showButtons}: SidebarFooterProps): JSX.Element => {
   return (
     <div className="bg-gray-50 dark:bg-gray-900 border-t dark:border-white/10 mt-auto p-2">
       <div className="max-w-screen-xl flex justify-center items-center flex-col">
-        <BrainManagementButton />
-        <UserButton />
+        {showButtons.includes('myBrains') && <BrainManagementButton />}
+        {showButtons.includes('user') && <UserButton />}
       </div>
     </div>
   );


### PR DESCRIPTION
# Epic

#1231 

# Description

When i'm on brains management or brain library:
- I see the "user" at the bottom of the left bar
- "Add new brain" goes up in the leftbar
## Checklist before requesting a review

## Screenshots (if appropriate):

### Before
<img width="243" alt="image" src="https://github.com/StanGirard/quivr/assets/67386567/10e86582-de3b-4c55-b3ac-1154d271ebba">


### After
