### PR TITLE
feat: enable CSP in all environments (local/preview/prod)

### DIFF
--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -9,20 +9,52 @@ const nextConfig = {
   },
   // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
   async headers() {
-    if (process.env.NEXT_PUBLIC_ENV === "prod") {
-      return [
-        {
-          source: "/(.*)",
-          headers: securityHeaders,
-        },
-      ];
-    } else {
-      return [];
-    }
+    return [
+      {
+        source: "/(.*)",
+        headers: securityHeaders,
+      },
+    ];
   },
 };
 
-const ContentSecurityPolicy = {
+const ContentSecurityPolicyLocal = {
+  "default-src": [
+    "'self'",
+    "https://fonts.googleapis.com",
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    "https://api.june.so",
+  ],
+  "connect-src": [
+    "'self'",
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_BACKEND_URL,
+    "https://api.june.so",
+    "https://api.openai.com",
+    "https://cdn.growthbook.io",
+    "https://vitals.vercel-insights.com/v1/vitals",
+  ],
+  "img-src": ["'self'", "https://www.gravatar.com", "data:"],
+  "media-src": [
+    "'self'",
+    "https://user-images.githubusercontent.com",
+    "http://localhost:3001",
+    "http://localhost:3001",
+    "https://quivr-cms.s3.eu-west-3.amazonaws.com",
+  ],
+  "script-src": [
+    "'unsafe-inline'",
+    "'unsafe-eval'",
+    "https://va.vercel-scripts.com/",
+    "http://localhost:3001",
+    "http://localhost:3001",
+    "https://www.google-analytics.com/",
+  ],
+  "frame-ancestors": ["'none'"],
+  "style-src": ["'unsafe-inline'", "http://localhost:3001"],
+};
+
+const ContentSecurityPolicyPreview = {
   "default-src": [
     "'self'",
     "https://fonts.googleapis.com",
@@ -56,6 +88,51 @@ const ContentSecurityPolicy = {
   "frame-ancestors": ["'none'"],
   "style-src": ["'unsafe-inline'", "https://www.quivr.app/"],
 };
+
+const ContentSecurityPolicyProd = {
+  "default-src": [
+    "'self'",
+    "https://fonts.googleapis.com",
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    "https://api.june.so",
+    "https://www.quivr.app/",
+  ],
+  "connect-src": [
+    "'self'",
+    process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.NEXT_PUBLIC_BACKEND_URL,
+    "https://api.june.so",
+    "https://api.openai.com",
+    "https://cdn.growthbook.io",
+    "https://vitals.vercel-insights.com/v1/vitals",
+  ],
+  "img-src": ["'self'", "https://www.gravatar.com", "data:"],
+  "media-src": [
+    "'self'",
+    "https://user-images.githubusercontent.com",
+    "https://www.quivr.app/",
+    "https://quivr-cms.s3.eu-west-3.amazonaws.com",
+  ],
+  "script-src": [
+    "'unsafe-inline'",
+    "'unsafe-eval'",
+    "https://va.vercel-scripts.com/",
+    "https://www.quivr.app/",
+    "https://www.google-analytics.com/",
+  ],
+  "frame-ancestors": ["'none'"],
+  "style-src": ["'unsafe-inline'", "https://www.quivr.app/"],
+};
+
+const EnvToCSP = {
+  local: ContentSecurityPolicyLocal,
+  preview: ContentSecurityPolicyPreview,
+  prod: ContentSecurityPolicyProd,
+};
+
+const ContentSecurityPolicy = process.env.NEXT_PUBLIC_ENV
+  ? EnvToCSP[process.env.NEXT_PUBLIC_ENV]
+  : {};
 
 const cspString = Object.entries(ContentSecurityPolicy)
   .map(([key, values]) => `${key} ${values.join(" ")};`)

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -18,12 +18,17 @@ const nextConfig = {
   },
 };
 
-const ContentSecurityPolicyLocal = {
+const ContentSecurityPolicy = {
   "default-src": [
     "'self'",
     "https://fonts.googleapis.com",
     process.env.NEXT_PUBLIC_SUPABASE_URL,
     "https://api.june.so",
+    {
+      prod: "https://www.quivr.app/",
+      preview: "https://preview.quivr.app/",
+      local: ["http://localhost:3000", "http://localhost:3001"],
+    },
   ],
   "connect-src": [
     "'self'",
@@ -38,106 +43,45 @@ const ContentSecurityPolicyLocal = {
   "media-src": [
     "'self'",
     "https://user-images.githubusercontent.com",
-    "http://localhost:3000",
-    "http://localhost:3001",
+    "https://www.quivr.app/",
     "https://quivr-cms.s3.eu-west-3.amazonaws.com",
   ],
   "script-src": [
     "'unsafe-inline'",
     "'unsafe-eval'",
     "https://va.vercel-scripts.com/",
-    "http://localhost:3000",
-    "http://localhost:3001",
+    {
+      prod: "https://www.quivr.app/",
+      preview: "https://preview.quivr.app/",
+      local: ["http://localhost:3000", "http://localhost:3001"],
+    },
     "https://www.google-analytics.com/",
   ],
   "frame-ancestors": ["'none'"],
   "style-src": [
     "'unsafe-inline'",
-    "http://localhost:3000",
-    "http://localhost:3001",
+    {
+      prod: "https://www.quivr.app/",
+      preview: "https://preview.quivr.app/",
+      local: ["http://localhost:3000", "http://localhost:3001"],
+    },
   ],
 };
 
-const ContentSecurityPolicyPreview = {
-  "default-src": [
-    "'self'",
-    "https://fonts.googleapis.com",
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    "https://api.june.so",
-    "https://preview.quivr.app/",
-  ],
-  "connect-src": [
-    "'self'",
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_BACKEND_URL,
-    "https://api.june.so",
-    "https://api.openai.com",
-    "https://cdn.growthbook.io",
-    "https://vitals.vercel-insights.com/v1/vitals",
-  ],
-  "img-src": ["'self'", "https://www.gravatar.com", "data:"],
-  "media-src": [
-    "'self'",
-    "https://user-images.githubusercontent.com",
-    "https://preview.quivr.app/",
-    "https://quivr-cms.s3.eu-west-3.amazonaws.com",
-  ],
-  "script-src": [
-    "'unsafe-inline'",
-    "'unsafe-eval'",
-    "https://va.vercel-scripts.com/",
-    "https://preview.quivr.app/",
-    "https://www.google-analytics.com/",
-  ],
-  "frame-ancestors": ["'none'"],
-  "style-src": ["'unsafe-inline'", "https://preview.quivr.app/"],
-};
+// Resolve environment-specific CSP values
+for (const directive of Object.values(ContentSecurityPolicy)) {
+  for (const [index, resource] of directive.entries()) {
+    if (typeof resource === "string") {
+      continue;
+    }
+    directive[index] = resource[process.env.NEXT_PUBLIC_ENV];
+    if (Array.isArray(directive[index])) {
+      directive[index] = directive[index].join(" ");
+    }
+  }
+}
 
-const ContentSecurityPolicyProd = {
-  "default-src": [
-    "'self'",
-    "https://fonts.googleapis.com",
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    "https://api.june.so",
-    "https://www.quivr.app/",
-  ],
-  "connect-src": [
-    "'self'",
-    process.env.NEXT_PUBLIC_SUPABASE_URL,
-    process.env.NEXT_PUBLIC_BACKEND_URL,
-    "https://api.june.so",
-    "https://api.openai.com",
-    "https://cdn.growthbook.io",
-    "https://vitals.vercel-insights.com/v1/vitals",
-  ],
-  "img-src": ["'self'", "https://www.gravatar.com", "data:"],
-  "media-src": [
-    "'self'",
-    "https://user-images.githubusercontent.com",
-    "https://www.quivr.app/",
-    "https://quivr-cms.s3.eu-west-3.amazonaws.com",
-  ],
-  "script-src": [
-    "'unsafe-inline'",
-    "'unsafe-eval'",
-    "https://va.vercel-scripts.com/",
-    "https://www.quivr.app/",
-    "https://www.google-analytics.com/",
-  ],
-  "frame-ancestors": ["'none'"],
-  "style-src": ["'unsafe-inline'", "https://www.quivr.app/"],
-};
-
-const EnvToCSP = {
-  local: ContentSecurityPolicyLocal,
-  preview: ContentSecurityPolicyPreview,
-  prod: ContentSecurityPolicyProd,
-};
-
-const ContentSecurityPolicy = process.env.NEXT_PUBLIC_ENV
-  ? EnvToCSP[process.env.NEXT_PUBLIC_ENV]
-  : {};
-
+// Build CSP string
 const cspString = Object.entries(ContentSecurityPolicy)
   .map(([key, values]) => `${key} ${values.join(" ")};`)
   .join(" ");

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -38,7 +38,7 @@ const ContentSecurityPolicyLocal = {
   "media-src": [
     "'self'",
     "https://user-images.githubusercontent.com",
-    "http://localhost:3001",
+    "http://localhost:3000",
     "http://localhost:3001",
     "https://quivr-cms.s3.eu-west-3.amazonaws.com",
   ],
@@ -46,12 +46,16 @@ const ContentSecurityPolicyLocal = {
     "'unsafe-inline'",
     "'unsafe-eval'",
     "https://va.vercel-scripts.com/",
-    "http://localhost:3001",
+    "http://localhost:3000",
     "http://localhost:3001",
     "https://www.google-analytics.com/",
   ],
   "frame-ancestors": ["'none'"],
-  "style-src": ["'unsafe-inline'", "http://localhost:3001"],
+  "style-src": [
+    "'unsafe-inline'",
+    "http://localhost:3000",
+    "http://localhost:3001",
+  ],
 };
 
 const ContentSecurityPolicyPreview = {
@@ -60,7 +64,7 @@ const ContentSecurityPolicyPreview = {
     "https://fonts.googleapis.com",
     process.env.NEXT_PUBLIC_SUPABASE_URL,
     "https://api.june.so",
-    "https://www.quivr.app/",
+    "https://preview.quivr.app/",
   ],
   "connect-src": [
     "'self'",
@@ -75,18 +79,18 @@ const ContentSecurityPolicyPreview = {
   "media-src": [
     "'self'",
     "https://user-images.githubusercontent.com",
-    "https://www.quivr.app/",
+    "https://preview.quivr.app/",
     "https://quivr-cms.s3.eu-west-3.amazonaws.com",
   ],
   "script-src": [
     "'unsafe-inline'",
     "'unsafe-eval'",
     "https://va.vercel-scripts.com/",
-    "https://www.quivr.app/",
+    "https://preview.quivr.app/",
     "https://www.google-analytics.com/",
   ],
   "frame-ancestors": ["'none'"],
-  "style-src": ["'unsafe-inline'", "https://www.quivr.app/"],
+  "style-src": ["'unsafe-inline'", "https://preview.quivr.app/"],
 };
 
 const ContentSecurityPolicyProd = {


### PR DESCRIPTION
# Description

Enable CSP in all environments (local/preview/prod).

Relies on NEXT_PUBLIC_ENV env variable, which should be `'local'|'preview'|'prod'`

# Comparison of old and new CSP values (tested locally)

## Before

### CSP (for prod only)

```
default-src 'self' https://fonts.googleapis.com https://xxx.supabase.co https://api.june.so https://www.quivr.app/; connect-src 'self' https://xxx.supabase.co http://localhost:5050 https://api.june.so https://api.openai.com https://cdn.growthbook.io https://vitals.vercel-insights.com/v1/vitals; img-src 'self' https://www.gravatar.com data:; media-src 'self' https://user-images.githubusercontent.com https://www.quivr.app/ https://quivr-cms.s3.eu-west-3.amazonaws.com; script-src 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com/ https://www.quivr.app/ https://www.google-analytics.com/; frame-ancestors 'none'; style-src 'unsafe-inline' https://www.quivr.app/;
```

## After

### Prod CSP (iso with before)

```
default-src 'self' https://fonts.googleapis.com https://xxx.supabase.co https://api.june.so https://www.quivr.app/; connect-src 'self' https://xxx.supabase.co http://localhost:5050 https://api.june.so https://api.openai.com https://cdn.growthbook.io https://vitals.vercel-insights.com/v1/vitals; img-src 'self' https://www.gravatar.com data:; media-src 'self' https://user-images.githubusercontent.com https://www.quivr.app/ https://quivr-cms.s3.eu-west-3.amazonaws.com; script-src 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com/ https://www.quivr.app/ https://www.google-analytics.com/; frame-ancestors 'none'; style-src 'unsafe-inline' https://www.quivr.app/;
```

### Preview CSP

```
default-src 'self' https://fonts.googleapis.com https://xxx.supabase.co https://api.june.so https://preview.quivr.app/; connect-src 'self' https://xxx.supabase.co http://localhost:5050 https://api.june.so https://api.openai.com https://cdn.growthbook.io https://vitals.vercel-insights.com/v1/vitals; img-src 'self' https://www.gravatar.com data:; media-src 'self' https://user-images.githubusercontent.com https://www.quivr.app/ https://quivr-cms.s3.eu-west-3.amazonaws.com; script-src 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com/ https://preview.quivr.app/ https://www.google-analytics.com/; frame-ancestors 'none'; style-src 'unsafe-inline' https://preview.quivr.app/;
```

### Local CSP

```
default-src 'self' https://fonts.googleapis.com https://xxx.supabase.co https://api.june.so http://localhost:3000 http://localhost:3001; connect-src 'self' https://xxx.supabase.co http://localhost:5050 https://api.june.so https://api.openai.com https://cdn.growthbook.io https://vitals.vercel-insights.com/v1/vitals; img-src 'self' https://www.gravatar.com data:; media-src 'self' https://user-images.githubusercontent.com https://www.quivr.app/ https://quivr-cms.s3.eu-west-3.amazonaws.com; script-src 'unsafe-inline' 'unsafe-eval' https://va.vercel-scripts.com/ http://localhost:3000 http://localhost:3001 https://www.google-analytics.com/; frame-ancestors 'none'; style-src 'unsafe-inline' http://localhost:3000 http://localhost:3001;
```

# 🧪 External checks

Syntax checked with https://csp-evaluator.withgoogle.com/ (for the 3 environments).