### PR TITLE
FIX tables.sql - missing ; breaks SQL queries.

### DIFF
--- a/scripts/tables.sql
+++ b/scripts/tables.sql
@@ -264,7 +264,7 @@ CREATE TABLE IF NOT EXISTS onboardings (
   onboarding_b2 BOOLEAN NOT NULL DEFAULT true,
   onboarding_b3 BOOLEAN NOT NULL DEFAULT true,
   PRIMARY KEY (user_id)
-)
+);
 
 insert into
   storage.buckets (id, name)


### PR DESCRIPTION
# Description

A missing ; in the CREATE query for onboarding tables breaks the script execution on Supabase.

## Checklist before requesting a review

Please delete options that are not relevant.

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my code
- [ x] Any dependent changes have been merged

## Screenshots (if appropriate):
