### PR TITLE
refactor: extract prompt from settings

### DIFF
--- a/backend/routes/brain_routes.py
+++ b/backend/routes/brain_routes.py
@@ -128,6 +128,8 @@ async def update_existing_brain(
     if existing_brain is None:
         raise HTTPException(status_code=404, detail="Brain not found")
 
+    update_brain_by_id(brain_id, brain_update_data)
+
     if brain_update_data.prompt_id is None and existing_brain.prompt_id:
         prompt = get_prompt_by_id(existing_brain.prompt_id)
         if prompt and prompt.status == "private":
@@ -136,7 +138,6 @@ async def update_existing_brain(
     if brain_update_data.status == "private" and existing_brain.status == "public":
         delete_brain_users(brain_id)
 
-    update_brain_by_id(brain_id, brain_update_data)
     return {"message": f"Brain {brain_id} has been updated."}
 
 

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/SettingsTab.tsx
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/SettingsTab.tsx
@@ -1,4 +1,4 @@
-/* eslint max-lines:["error", 125] */
+/* eslint max-lines:["error", 135] */
 
 import { UUID } from "crypto";
 import { useTranslation } from "react-i18next";
@@ -12,6 +12,7 @@ import { AccessConfirmationModal } from "./components/PrivateAccessConfirmationM
 import { useAccessConfirmationModal } from "./components/PrivateAccessConfirmationModal/hooks/useAccessConfirmationModal";
 import { useSettingsTab } from "./hooks/useSettingsTab";
 import { getBrainPermissions } from "../../utils/getBrainPermissions";
+
 
 type SettingsTabProps = {
   brainId: UUID;
@@ -37,10 +38,25 @@ export const SettingsTab = ({ brainId }: SettingsTabProps): JSX.Element => {
     setValue,
     dirtyFields,
     resetField,
-    pickPublicPrompt,
+    setIsUpdating,
     promptId,
-    removeBrainPrompt,
+    getValues,
+    reset,
+    updateFormValues,
   } = useSettingsTab({ brainId });
+
+  const promptProps = {
+    brainId,
+    getValues,
+    promptId,
+    register,
+    reset,
+    setValue,
+    resetField,
+    updateFormValues,
+    dirtyFields,
+    setIsUpdating,
+  };
 
   const { onCancel, isAccessModalOpened, closeModal } =
     useAccessConfirmationModal({
@@ -91,13 +107,8 @@ export const SettingsTab = ({ brainId }: SettingsTabProps): JSX.Element => {
         />
         <Divider text={t("customPromptSection", { ns: "config" })} />
         <Prompt
-          brainId={brainId}
-          handleSubmit={handleSubmit}
-          isUpdating={isUpdating}
-          pickPublicPrompt={pickPublicPrompt}
-          removeBrainPrompt={removeBrainPrompt}
-          promptId={promptId}
-          register={register}
+          usePromptProps={promptProps}
+          isUpdatingBrain={isUpdating}
           hasEditRights={hasEditRights}
         />
         <div className="flex flex-row justify-end flex-1 w-full mt-8">

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/components/Prompt/Prompt.tsx
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/components/Prompt/Prompt.tsx
@@ -1,43 +1,31 @@
-import { UUID } from "crypto";
-import { UseFormRegister } from "react-hook-form";
 import { useTranslation } from "react-i18next";
 
 import Button from "@/lib/components/ui/Button";
 import Field from "@/lib/components/ui/Field";
 import { TextArea } from "@/lib/components/ui/TextArea";
-import { BrainConfig } from "@/lib/types/brainConfig";
 import { SaveButton } from "@/shared/SaveButton";
 
+import { usePrompt, UsePromptProps } from "../../hooks/usePrompt";
 import { PublicPrompts } from "../PublicPrompts";
 
 type PromptProps = {
-  brainId: UUID;
-  pickPublicPrompt: ({
-    title,
-    content,
-  }: {
-    title: string;
-    content: string;
-  }) => void;
-  removeBrainPrompt: () => Promise<void>;
-  isUpdating: boolean;
-  handleSubmit: (checkDirty: boolean) => Promise<void>;
-  register: UseFormRegister<BrainConfig>;
-  promptId?: string;
+  usePromptProps: UsePromptProps;
+  isUpdatingBrain: boolean;
   hasEditRights: boolean;
 };
 
 export const Prompt = (props: PromptProps): JSX.Element => {
   const { t } = useTranslation(["translation", "brain", "config"]);
+  const { isUpdatingBrain, hasEditRights, usePromptProps } = props;
+
   const {
     pickPublicPrompt,
-    removeBrainPrompt,
-    isUpdating,
-    handleSubmit,
     register,
-    hasEditRights,
+    submitPrompt,
     promptId,
-  } = props;
+    isRemovingPrompt,
+    removeBrainPrompt,
+  } = usePrompt(usePromptProps);
 
   return (
     <>
@@ -60,11 +48,14 @@ export const Prompt = (props: PromptProps): JSX.Element => {
       />
       {hasEditRights && (
         <div className="flex w-full justify-end py-4">
-          <SaveButton handleSubmit={handleSubmit} />
+          <SaveButton handleSubmit={submitPrompt} />
         </div>
       )}
       {hasEditRights && promptId !== "" && (
-        <Button disabled={isUpdating} onClick={() => void removeBrainPrompt()}>
+        <Button
+          disabled={isUpdatingBrain || isRemovingPrompt}
+          onClick={() => void removeBrainPrompt()}
+        >
           {t("removePrompt", { ns: "config" })}
         </Button>
       )}

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/hooks/usePrompt.ts
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/hooks/usePrompt.ts
@@ -1,0 +1,223 @@
+/* eslint-disable max-lines */
+import axios from "axios";
+import { UUID } from "crypto";
+import { useEffect, useState } from "react";
+import {
+  UseFormGetValues,
+  UseFormRegister,
+  UseFormReset,
+  UseFormResetField,
+  UseFormSetValue,
+} from "react-hook-form";
+import { useTranslation } from "react-i18next";
+
+import { useBrainApi } from "@/lib/api/brain/useBrainApi";
+import { usePromptApi } from "@/lib/api/prompt/usePromptApi";
+import { useBrainContext } from "@/lib/context/BrainProvider/hooks/useBrainContext";
+import { useToast } from "@/lib/hooks";
+import { BrainConfig } from "@/lib/types/brainConfig";
+
+type DirtyFields<T> = {
+  [K in keyof T]?: T[K] extends object
+    ? DirtyFields<T[K]>
+    : boolean | undefined;
+};
+
+export type UsePromptProps = {
+  brainId: UUID;
+  getValues: UseFormGetValues<BrainConfig>;
+  promptId: string | undefined;
+  register: UseFormRegister<BrainConfig>;
+  reset: UseFormReset<BrainConfig>;
+  setValue: UseFormSetValue<BrainConfig>;
+  setIsUpdating: (isUpdating: boolean) => void;
+  resetField: UseFormResetField<BrainConfig>;
+  updateFormValues: () => void;
+  dirtyFields: DirtyFields<BrainConfig>;
+};
+
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const usePrompt = (props: UsePromptProps) => {
+  const { t } = useTranslation(["translation", "brain", "config"]);
+  const { publish } = useToast();
+  const { updateBrain } = useBrainApi();
+  const { getPrompt, updatePrompt, createPrompt } = usePromptApi();
+  const [isRemovingPrompt, setIsRemovingPrompt] = useState(false);
+  const { fetchAllBrains } = useBrainContext();
+
+  const {
+    brainId,
+    dirtyFields,
+    getValues,
+    promptId,
+    register,
+    reset,
+    setValue,
+    resetField,
+    updateFormValues,
+    setIsUpdating,
+  } = props;
+
+  const [currentPromptId, setCurrentPromptId] = useState<string | undefined>(
+    promptId
+  );
+  console.log("DIRTY FIELDS", dirtyFields);
+
+  const fetchPrompt = async () => {
+    if (currentPromptId === "" || currentPromptId === undefined) {
+      return;
+    }
+
+    const prompt = await getPrompt(currentPromptId);
+    if (prompt === undefined) {
+      return;
+    }
+    setValue("prompt", prompt);
+  };
+  useEffect(() => {
+    void fetchPrompt();
+  }, [currentPromptId]);
+
+  const removeBrainPrompt = async () => {
+    try {
+      setIsRemovingPrompt(true);
+      await updateBrain(brainId, {
+        prompt_id: null,
+      });
+      setValue("prompt", {
+        title: "",
+        content: "",
+      });
+      reset();
+      void updateFormValues();
+      publish({
+        variant: "success",
+        text: t("promptRemoved", { ns: "config" }),
+      });
+      setCurrentPromptId(undefined);
+    } catch (err) {
+      publish({
+        variant: "danger",
+        text: t("errorRemovingPrompt", { ns: "config" }),
+      });
+    } finally {
+      setIsRemovingPrompt(false);
+    }
+  };
+
+  const promptHandler = async () => {
+    const { prompt } = getValues();
+
+    if (dirtyFields["prompt"] && promptId !== undefined) {
+      await updatePrompt(promptId, {
+        title: prompt.title,
+        content: prompt.content,
+      });
+    }
+  };
+
+  // eslint-disable-next-line complexity
+  const submitPrompt = async () => {
+    const {
+      prompt,
+      maxTokens: max_tokens,
+      openAiKey: openai_api_key,
+      ...otherConfigs
+    } = getValues();
+
+    if (!dirtyFields["prompt"]) {
+      return;
+    }
+    console.log("PROMPT", prompt);
+    if (prompt.content === "" || prompt.title === "") {
+      publish({
+        variant: "warning",
+        text: t("promptFieldsRequired", { ns: "config" }),
+      });
+
+      return;
+    }
+
+    try {
+      console.log("PROMPTID", promptId);
+      if (promptId === "" || promptId === undefined) {
+        console.log("CREATING PROMPT");
+        otherConfigs["prompt_id"] = (
+          await createPrompt({
+            title: prompt.title,
+            content: prompt.content,
+          })
+        ).id;
+        console.log("OTHER CONFIGS", otherConfigs);
+        await updateBrain(brainId, {
+          ...otherConfigs,
+          max_tokens,
+          openai_api_key,
+        });
+        void updateFormValues();
+      } else {
+        await Promise.all([
+          updateBrain(brainId, {
+            ...otherConfigs,
+            max_tokens,
+            openai_api_key,
+          }),
+          promptHandler(),
+        ]);
+      }
+      void fetchAllBrains();
+
+      publish({
+        variant: "success",
+        text: t("brainUpdated", { ns: "config" }),
+      });
+    } catch (err) {
+      if (axios.isAxiosError(err) && err.response?.status === 429) {
+        publish({
+          variant: "danger",
+          text: `${JSON.stringify(
+            (
+              err.response as {
+                data: { detail: string };
+              }
+            ).data.detail
+          )}`,
+        });
+      } else {
+        publish({
+          variant: "danger",
+          text: `${JSON.stringify(err)}`,
+        });
+      }
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  const pickPublicPrompt = ({
+    title,
+    content,
+  }: {
+    title: string;
+    content: string;
+  }): void => {
+    setValue("prompt.title", title, {
+      shouldDirty: true,
+    });
+    setValue("prompt.content", content, {
+      shouldDirty: true,
+    });
+  };
+
+  return {
+    register,
+    pickPublicPrompt,
+    submitPrompt,
+    removeBrainPrompt,
+    setValue,
+    isRemovingPrompt,
+    promptId,
+    dirtyFields,
+    resetField,
+  };
+};

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/hooks/usePrompt.ts
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/hooks/usePrompt.ts
@@ -61,7 +61,6 @@ export const usePrompt = (props: UsePromptProps) => {
   const [currentPromptId, setCurrentPromptId] = useState<string | undefined>(
     promptId
   );
-  console.log("DIRTY FIELDS", dirtyFields);
 
   const fetchPrompt = async () => {
     if (currentPromptId === "" || currentPromptId === undefined) {
@@ -128,7 +127,7 @@ export const usePrompt = (props: UsePromptProps) => {
     if (!dirtyFields["prompt"]) {
       return;
     }
-    console.log("PROMPT", prompt);
+
     if (prompt.content === "" || prompt.title === "") {
       publish({
         variant: "warning",
@@ -139,9 +138,7 @@ export const usePrompt = (props: UsePromptProps) => {
     }
 
     try {
-      console.log("PROMPTID", promptId);
       if (promptId === "" || promptId === undefined) {
-        console.log("CREATING PROMPT");
         otherConfigs["prompt_id"] = (
           await createPrompt({
             title: prompt.title,

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/hooks/useSettingsTab.ts
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/hooks/useSettingsTab.ts
@@ -15,8 +15,8 @@ import { useToast } from "@/lib/hooks";
 import { useUserData } from "@/lib/hooks/useUserData";
 import { BrainStatus } from "@/lib/types/brainConfig";
 
-import { useBrainFormState } from "./useBrainFormState";
 import { validateOpenAIKey } from "../utils/validateOpenAIKey";
+import { useBrainFormState } from "./useBrainFormState";
 
 type UseSettingsTabProps = {
   brainId: UUID;

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/hooks/useSettingsTab.ts
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/hooks/useSettingsTab.ts
@@ -6,7 +6,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useBrainApi } from "@/lib/api/brain/useBrainApi";
-import { usePromptApi } from "@/lib/api/prompt/usePromptApi";
 import { useBrainContext } from "@/lib/context/BrainProvider/hooks/useBrainContext";
 import { Brain } from "@/lib/context/BrainProvider/types";
 import { defineMaxTokens } from "@/lib/helpers/defineMaxTokens";
@@ -15,8 +14,9 @@ import { useToast } from "@/lib/hooks";
 import { useUserData } from "@/lib/hooks/useUserData";
 import { BrainStatus } from "@/lib/types/brainConfig";
 
-import { validateOpenAIKey } from "../utils/validateOpenAIKey";
 import { useBrainFormState } from "./useBrainFormState";
+import { checkBrainName } from "../utils/checkBrainName";
+import { checkOpenAiKey } from "../utils/checkOpenAiKey";
 
 type UseSettingsTabProps = {
   brainId: UUID;
@@ -31,7 +31,6 @@ export const useSettingsTab = ({ brainId }: UseSettingsTabProps) => {
   const formRef = useRef<HTMLFormElement>(null);
   const { setAsDefaultBrain, updateBrain } = useBrainApi();
   const { fetchAllBrains, fetchDefaultBrain } = useBrainContext();
-  const { getPrompt, updatePrompt, createPrompt } = usePromptApi();
   const { userData } = useUserData();
 
   const {
@@ -128,21 +127,6 @@ export const useSettingsTab = ({ brainId }: UseSettingsTabProps) => {
     };
   }, [formRef.current]);
 
-  const fetchPrompt = async () => {
-    if (promptId === "" || promptId === undefined) {
-      return;
-    }
-
-    const prompt = await getPrompt(promptId);
-    if (prompt === undefined) {
-      return;
-    }
-    setValue("prompt", prompt);
-  };
-  useEffect(() => {
-    void fetchPrompt();
-  }, [promptId]);
-
   const setAsDefaultBrainHandler = async () => {
     try {
       setIsSettingAsDefault(true);
@@ -173,43 +157,6 @@ export const useSettingsTab = ({ brainId }: UseSettingsTabProps) => {
     }
   };
 
-  const removeBrainPrompt = async () => {
-    try {
-      setIsUpdating(true);
-      await updateBrain(brainId, {
-        prompt_id: null,
-      });
-      setValue("prompt", {
-        title: "",
-        content: "",
-      });
-      reset();
-      void updateFormValues();
-      publish({
-        variant: "success",
-        text: t("promptRemoved", { ns: "config" }),
-      });
-    } catch (err) {
-      publish({
-        variant: "danger",
-        text: t("errorRemovingPrompt", { ns: "config" }),
-      });
-    } finally {
-      setIsUpdating(false);
-    }
-  };
-
-  const promptHandler = async () => {
-    const { prompt } = getValues();
-
-    if (dirtyFields["prompt"] && promptId !== undefined) {
-      await updatePrompt(promptId, {
-        title: prompt.title,
-        content: prompt.content,
-      });
-    }
-  };
-
   const handleSubmit = async (checkDirty: boolean) => {
     const hasChanges = Object.keys(dirtyFields).length > 0;
     if (!hasChanges && checkDirty) {
@@ -217,81 +164,22 @@ export const useSettingsTab = ({ brainId }: UseSettingsTabProps) => {
     }
     const { name, openAiKey: openai_api_key } = getValues();
 
-    if (name.trim() === "") {
-      publish({
-        variant: "danger",
-        text: t("nameRequired", { ns: "config" }),
-      });
-
-      return;
-    }
-
-    if (
-      openai_api_key !== undefined &&
-      openai_api_key !== "" &&
-      !(await validateOpenAIKey(
-        openai_api_key,
-        {
-          badApiKeyError: t("incorrectApiKey", { ns: "config" }),
-          invalidApiKeyError: t("invalidApiKeyError", { ns: "config" }),
-        },
-        publish
-      ))
-    ) {
-      return;
-    }
+    checkBrainName(name, publish, t);
+    await checkOpenAiKey(openai_api_key, publish, t);
 
     try {
       setIsUpdating(true);
-      const { maxTokens: max_tokens, prompt, ...otherConfigs } = getValues();
+      const { maxTokens: max_tokens, ...otherConfigs } = getValues();
 
-      if (
-        dirtyFields["prompt"] &&
-        (prompt.content === "" || prompt.title === "")
-      ) {
-        publish({
-          variant: "warning",
-          text: t("promptFieldsRequired", { ns: "config" }),
-        });
-
-        return;
-      }
-
-      if (dirtyFields["prompt"]) {
-        if (promptId === "" || promptId === undefined) {
-          otherConfigs["prompt_id"] = (
-            await createPrompt({
-              title: prompt.title,
-              content: prompt.content,
-            })
-          ).id;
-          await updateBrain(brainId, {
-            ...otherConfigs,
-            max_tokens,
-            openai_api_key,
-          });
-          void updateFormValues();
-        } else {
-          await Promise.all([
-            updateBrain(brainId, {
-              ...otherConfigs,
-              max_tokens,
-              openai_api_key,
-            }),
-            promptHandler(),
-          ]);
-        }
-      } else {
-        await updateBrain(brainId, {
-          ...otherConfigs,
-          max_tokens,
-          openai_api_key,
-          prompt_id:
-            otherConfigs["prompt_id"] !== ""
-              ? otherConfigs["prompt_id"]
-              : undefined,
-        });
-      }
+      await updateBrain(brainId, {
+        ...otherConfigs,
+        max_tokens,
+        openai_api_key,
+        prompt_id:
+          otherConfigs["prompt_id"] !== ""
+            ? otherConfigs["prompt_id"]
+            : undefined,
+      });
 
       publish({
         variant: "success",
@@ -321,26 +209,9 @@ export const useSettingsTab = ({ brainId }: UseSettingsTabProps) => {
     }
   };
 
-  const pickPublicPrompt = ({
-    title,
-    content,
-  }: {
-    title: string;
-    content: string;
-  }): void => {
-    setValue("prompt.title", title, {
-      shouldDirty: true,
-    });
-    setValue("prompt.content", content, {
-      shouldDirty: true,
-    });
-  };
-
   return {
     handleSubmit,
     register,
-    removeBrainPrompt,
-    pickPublicPrompt,
     setAsDefaultBrainHandler,
     setValue,
     brain,
@@ -357,5 +228,9 @@ export const useSettingsTab = ({ brainId }: UseSettingsTabProps) => {
     status,
     dirtyFields,
     resetField,
+    updateFormValues,
+    reset,
+    getValues,
+    setIsUpdating,
   };
 };

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/utils/checkBrainName.ts
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/utils/checkBrainName.ts
@@ -1,0 +1,18 @@
+import { TFunction } from "i18next";
+
+import { ToastData } from "@/lib/components/ui/Toast/domain/types";
+
+export const checkBrainName = (
+  name: string,
+  publish: (toast: ToastData) => void,
+  t: TFunction<["translation", "brain", "config"]>
+): void => {
+  if (name.trim() === "") {
+    publish({
+      variant: "danger",
+      text: t("nameRequired", { ns: "config" }),
+    });
+
+    return;
+  }
+};

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/utils/checkOpenAiKey.ts
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/utils/checkOpenAiKey.ts
@@ -1,0 +1,26 @@
+import { TFunction } from "i18next";
+
+import { ToastData } from "@/lib/components/ui/Toast/domain/types";
+
+import { validateOpenAIKey } from "./validateOpenAIKey";
+
+export const checkOpenAiKey = async (
+  openai_api_key: string | undefined,
+  publish: (toast: ToastData) => void,
+  t: TFunction<["translation", "brain", "config"]>
+): Promise<void> => {
+  if (
+    openai_api_key !== undefined &&
+    openai_api_key !== "" &&
+    !(await validateOpenAIKey(
+      openai_api_key,
+      {
+        badApiKeyError: t("incorrectApiKey", { ns: "config" }),
+        invalidApiKeyError: t("invalidApiKeyError", { ns: "config" }),
+      },
+      publish
+    ))
+  ) {
+    return;
+  }
+};


### PR DESCRIPTION
# Description

- Refactor useSettingsTab by extracting usePrompt and methods in utils
- Fix bug #1545 

## Checklist before requesting a review

Please delete options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented hard-to-understand areas
- [ ] I have ideally added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

## Screenshots (if appropriate):
