### PR TITLE
style(prompts): update public prompts dropdown styling

### DIFF
--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/components/PublicPrompts/components/PublicPromptsList/PublicPromptsList.tsx
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/components/PublicPrompts/components/PublicPromptsList/PublicPromptsList.tsx
@@ -38,7 +38,7 @@ export const PublicPromptsList = ({
         {selectedOption ? selectedOption.title : t("selectQuivrPersonalityBtn", { ns: "config" })}
       </button>
       {isOpen && (
-        <div className="absolute top-10 w-full bg-white border rounded-md shadow-lg">
+        <div className="absolute top-10 w-full bg-white border rounded-md shadow-lg z-10">
           {options.map((option) => (
             <div
               key={option.id}

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/components/PublicPrompts/components/PublicPromptsList/PublicPromptsList.tsx
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/SettingsTab/components/PublicPrompts/components/PublicPromptsList/PublicPromptsList.tsx
@@ -42,7 +42,7 @@ export const PublicPromptsList = ({
           {options.map((option) => (
             <div
               key={option.id}
-              className="px-4 py-2 cursor-pointer hover:bg-gray-100"
+              className="px-4 py-2 cursor-pointer hover:bg-gray-100 text-gray-700"
               onClick={() => handleOptionClick(option)}
             >
               {option.title}


### PR DESCRIPTION
# Description

In https://www.quivr.app/brains-management, the Custom Prompt dropdown is partially covered by the cu

## Checklist before requesting a review

Please delete options that are not relevant.

- [X ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my code
- [ X] I have commented hard-to-understand areas
- [ X] I have ideally added tests that prove my fix is effective or that my feature works
- [ X] New and existing unit tests pass locally with my changes
- [ X] Any dependent changes have been merged

## Screenshots (if appropriate):
![quivr-custom-prompt-after](https://github.com/StanGirard/quivr/assets/149593769/7a063624-dea5-41f2-bcfb-369b60387bbd)
![quivr-custom-prompt-before](https://github.com/StanGirard/quivr/assets/149593769/5c42dd45-3af8-44b3-9137-121ec5a0bce6)
![quivr-custom-prompt-light-mode-before](https://github.com/StanGirard/quivr/assets/149593769/4872c5d0-1a0f-4ed9-9d2e-8acba3841953)
