### PR TITLE
Fix #1290 issue running migrations

### DIFF
--- a/migration.sh
+++ b/migration.sh
@@ -62,7 +62,7 @@ else
             echo "Running migration $file"
             run_sql_file "scripts/$file"
             # And record it as having been run
-            PGPASSWORD=${DB_PASSWORD} psql -h "${DB_HOST}" -p "${DB_PORT}" -d "${DB_NAME}" -U "${DB_USER}" -c "INSERT INTO migrations (id) VALUES ('${MIGRATION_ID}');"
+            PGPASSWORD=${DB_PASSWORD} psql -h "${DB_HOST}" -p "${DB_PORT}" -d "${DB_NAME}" -U "${DB_USER}" -c "INSERT INTO migrations (name) VALUES ('${MIGRATION_ID}');"
         fi
     done
 fi


### PR DESCRIPTION
# Description

In issue #1290 folks report difficulty running migrations on an existing instance. The current migration table includes a `name` column, but no `id` column:

```
CREATE TABLE IF NOT EXISTS migrations (
  name VARCHAR(255)  PRIMARY KEY,
  executed_at TIMESTAMPTZ DEFAULT current_timestamp
);
```

By changing the `migrations.sh` script to use the `name` field, the migrations run as expected. 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

