### PR TITLE
Use 'unless-stopped' instead of 'always' for development

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
       - /app/node_modules
       - /app/.next
     container_name: web
-    restart: always
+    restart: unless-stopped
     ports:
       - 3000:3000
 
@@ -25,7 +25,7 @@ services:
       args:
         - DEV_MODE=true
     container_name: backend-core
-    restart: always
+    restart: unless-stopped
     volumes:
       - ./backend/:/code/
     depends_on:
@@ -38,7 +38,7 @@ services:
   redis:
     image: redis:latest
     container_name: redis
-    restart: always
+    restart: unless-stopped
     ports:
       - 6379:6379
 
@@ -50,7 +50,7 @@ services:
       dockerfile: Dockerfile
     container_name: worker
     command: celery -A celery_worker worker -l info
-    restart: always
+    restart: unless-stopped
     depends_on:
       - redis
     volumes:
@@ -64,7 +64,7 @@ services:
       dockerfile: Dockerfile
     container_name: flower
     command: celery -A celery_worker flower -l info --port=5555
-    restart: always
+    restart: unless-stopped
     volumes:
       - ./backend/:/code/
     depends_on:


### PR DESCRIPTION
# Description

When developing locally, I am reluctant to start containers with the `restart: always` option. I find they stick around longer than I want them to. In my opinion, `restart: unless-stopped` is a nice middle ground. 

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

