### PR TITLE
fix: brain management shared brain access

### DIFF
--- a/backend/routes/brain_routes.py
+++ b/backend/routes/brain_routes.py
@@ -62,7 +62,14 @@ async def retrieve_default_brain(
 
 @brain_router.get(
     "/brains/{brain_id}/",
-    dependencies=[Depends(AuthBearer()), Depends(has_brain_authorization())],
+    dependencies=[
+        Depends(AuthBearer()),
+        Depends(
+            has_brain_authorization(
+                required_roles=[RoleEnum.Owner, RoleEnum.Editor, RoleEnum.Viewer]
+            )
+        ),
+    ],
     tags=["Brain"],
 )
 async def retrieve_brain_by_id(brain_id: UUID):

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/BrainManagementTabs.tsx
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/BrainManagementTabs.tsx
@@ -27,6 +27,7 @@ export const BrainManagementTabs = (): JSX.Element => {
     isDeleteOrUnsubscribeModalOpened,
     setIsDeleteOrUnsubscribeModalOpened,
     hasEditRights,
+    isPublicBrain,
     isOwnedByCurrentUser,
     isDeleteOrUnsubscribeRequestPending,
   } = useBrainManagementTabs();
@@ -51,7 +52,7 @@ export const BrainManagementTabs = (): JSX.Element => {
             value="settings"
             onChange={setSelectedTab}
           />
-          {hasEditRights && (
+          {(!isPublicBrain || hasEditRights) && (
             <>
               <BrainTabTrigger
                 selected={selectedTab === "people"}
@@ -74,10 +75,10 @@ export const BrainManagementTabs = (): JSX.Element => {
             <SettingsTab brainId={brainId} />
           </Content>
           <Content value="people">
-            <PeopleTab brainId={brainId} />
+            <PeopleTab brainId={brainId} hasEditRights={hasEditRights} />
           </Content>
           <Content value="knowledge">
-            <KnowledgeTab brainId={brainId} />
+            <KnowledgeTab brainId={brainId} hasEditRights={hasEditRights} />
           </Content>
         </div>
 

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/KnowledgeTab/index.tsx
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/KnowledgeTab/index.tsx
@@ -7,12 +7,21 @@ import { KnowledgeToFeedProvider } from "@/lib/context";
 
 import { AddKnowledge } from "./components/AddKnowledge/AddKnowledge";
 import { AddedKnowledge } from "./components/AddedKnowledge/AddedKnowledge";
+import { NoAccess } from "../NoAccess";
 
 type KnowledgeTabProps = {
   brainId: UUID;
+  hasEditRights: boolean;
 };
-export const KnowledgeTab = ({ brainId }: KnowledgeTabProps): JSX.Element => {
+export const KnowledgeTab = ({
+  brainId,
+  hasEditRights,
+}: KnowledgeTabProps): JSX.Element => {
   const { t } = useTranslation(["translation", "explore", "config"]);
+
+  if (!hasEditRights) {
+    return <NoAccess />;
+  }
 
   return (
     <KnowledgeToFeedProvider>

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/NoAccess.tsx
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/NoAccess.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useTranslation } from "react-i18next";
+
+export const NoAccess = (): JSX.Element => {
+  const { t } = useTranslation(["translation", "config", "brain"]);
+
+  return (
+    <div className="flex justify-center items-center mt-5">
+      <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative max-w-md">
+        <strong className="font-bold mr-1">
+          {t("ohno", { ns: "config" })}
+        </strong>
+        <span className="block sm:inline">
+          {t("roleRequired", { ns: "config" })}
+        </span>
+        <p>{t("requireAccess", { ns: "config" })}</p>
+      </div>
+    </div>
+  );
+};

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/PeopleTab/PeopleTab.tsx
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/components/PeopleTab/PeopleTab.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines */
 "use client";
 
 import { UUID } from "crypto";
@@ -11,12 +10,18 @@ import { UserToInvite } from "@/lib/components/UserToInvite";
 import Button from "@/lib/components/ui/Button";
 import { useShareBrain } from "@/lib/hooks/useShareBrain";
 
+import { NoAccess } from "../NoAccess";
+
 type ShareBrainModalProps = {
   brainId: UUID;
+  hasEditRights: boolean;
 };
 
-export const PeopleTab = ({ brainId }: ShareBrainModalProps): JSX.Element => {
-  const { t } = useTranslation(["translation","config","brain"]);
+export const PeopleTab = ({
+  brainId,
+  hasEditRights,
+}: ShareBrainModalProps): JSX.Element => {
+  const { t } = useTranslation(["translation", "config", "brain"]);
   const {
     roleAssignations,
     handleCopyInvitationLink,
@@ -26,21 +31,10 @@ export const PeopleTab = ({ brainId }: ShareBrainModalProps): JSX.Element => {
     addNewRoleAssignationRole,
     sendingInvitation,
     canAddNewRow,
-    hasShareBrainRights,
   } = useShareBrain(brainId);
 
-  if (!hasShareBrainRights) {
-    return (
-      <div className="flex justify-center items-center mt-5">
-        <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative max-w-md">
-          <strong className="font-bold mr-1">{t("ohno",{ns:"config"})}</strong>
-          <span className="block sm:inline">
-            {t("roleRequired",{ns:"config"})}
-          </span>
-          <p>{t("requireAccess",{ns:"config"})}</p>
-        </div>
-      </div>
-    );
+  if (!hasEditRights) {
+    return <NoAccess />;
   }
 
   return (
@@ -62,7 +56,7 @@ export const PeopleTab = ({ brainId }: ShareBrainModalProps): JSX.Element => {
               </div>
               <div className="flex flex-row flex-1 items-center justify-center">
                 <span className="text-sm text-gray-700 dark:text-gray-200 w-full bg-gray-50 dark:bg-gray-900 px-4 py-2">
-                  {t("shareBrainLink",{ns:"brain"})}
+                  {t("shareBrainLink", { ns: "brain" })}
                 </span>
               </div>
               <Button type="button">
@@ -72,7 +66,9 @@ export const PeopleTab = ({ brainId }: ShareBrainModalProps): JSX.Element => {
           </div>
 
           <div className="bg-gray-100 h-0.5 my-10 border-gray-200 dark:border-gray-700" />
-          <p className="text-lg font-bold">{t("inviteUsers",{ns:"brain"})}</p>
+          <p className="text-lg font-bold">
+            {t("inviteUsers", { ns: "brain" })}
+          </p>
 
           {roleAssignations.map((roleAssignation, index) => (
             <UserToInvite
@@ -98,12 +94,14 @@ export const PeopleTab = ({ brainId }: ShareBrainModalProps): JSX.Element => {
             disabled={roleAssignations.length === 0}
             type="submit"
           >
-            {t("shareButton",{ns:"translation"})}
+            {t("shareButton", { ns: "translation" })}
           </Button>
         </div>
       </form>
       <div className="bg-gray-100 h-0.5 my-10 border-gray-200 dark:border-gray-700" />
-      <p className="text-lg font-bold">{t("usersWithAccess",{ns:"brain"})}</p>
+      <p className="text-lg font-bold">
+        {t("usersWithAccess", { ns: "brain" })}
+      </p>
       <BrainUsers brainId={brainId} />
     </>
   );

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/hooks/useBrainFetcher.ts
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/hooks/useBrainFetcher.ts
@@ -22,15 +22,18 @@ export const useBrainFetcher = ({ brainId }: UseBrainFetcherProps) => {
 
       return await getBrain(brainId);
     } catch (error) {
+      console.log("error", error);
       router.push("/brains-management");
     }
   };
 
+  console.log("brainId", brainId);
   const { data: brain } = useQuery({
     queryKey: [getBrainDataKey(brainId!)],
     queryFn: fetchBrain,
     enabled: brainId !== undefined,
   });
+  console.log("QUERY DATA", brain);
 
   return {
     brain,

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/hooks/useBrainManagementTabs.ts
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/hooks/useBrainManagementTabs.ts
@@ -44,10 +44,11 @@ export const useBrainManagementTabs = () => {
   const { t } = useTranslation(["delete_or_unsubscribe_from_brain"]);
   const brainId = params?.brainId as UUID | undefined;
 
-  const { hasEditRights, isOwnedByCurrentUser } = getBrainPermissions({
-    brainId,
-    userAccessibleBrains: allBrains,
-  });
+  const { hasEditRights, isOwnedByCurrentUser, isPublicBrain } =
+    getBrainPermissions({
+      brainId,
+      userAccessibleBrains: allBrains,
+    });
 
   const handleUnSubscription = async () => {
     if (brainId === undefined) {
@@ -94,5 +95,6 @@ export const useBrainManagementTabs = () => {
     hasEditRights,
     isOwnedByCurrentUser,
     isDeleteOrUnsubscribeRequestPending,
+    isPublicBrain,
   };
 };

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/utils/getBrainPermissions.ts
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/utils/getBrainPermissions.ts
@@ -2,7 +2,8 @@ import { UUID } from "crypto";
 
 import { MinimalBrainForUser } from "@/lib/context/BrainProvider/types";
 
-import { isUserBrainOwner } from "./isUserBrainOwner";
+import { isUserBrainOwner } from "./isUserBrainEditor";
+import { isUserBrainEditor } from "./isUserBrainOwner";
 
 type GetBrainPermissionsProps = {
   brainId?: UUID;
@@ -22,11 +23,17 @@ export const getBrainPermissions = ({
     userAccessibleBrains,
   });
 
+  const userHasBrainEditorRights = isUserBrainEditor({
+    brainId,
+    userAccessibleBrains,
+  });
+
   const isPublicBrain =
     userAccessibleBrains.find((brain) => brain.id === brainId)?.status ===
     "public";
 
-  const hasEditRights = !isPublicBrain || isOwnedByCurrentUser;
+  console.log("isPublicBrain", isPublicBrain);
+  const hasEditRights = isOwnedByCurrentUser || userHasBrainEditorRights;
 
   return { isPublicBrain, hasEditRights, isOwnedByCurrentUser };
 };

--- a/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/utils/isUserBrainEditor.ts
+++ b/frontend/app/brains-management/[brainId]/components/BrainManagementTabs/utils/isUserBrainEditor.ts
@@ -6,7 +6,7 @@ type IsUserBrainOwnerProps = {
   userAccessibleBrains: MinimalBrainForUser[];
   brainId?: UUID;
 };
-export const isUserBrainEditor = ({
+export const isUserBrainOwner = ({
   brainId,
   userAccessibleBrains,
 }: IsUserBrainOwnerProps): boolean => {
@@ -15,5 +15,5 @@ export const isUserBrainEditor = ({
     return false;
   }
 
-  return brain.role === "Editor";
+  return brain.role === "Owner";
 };

--- a/frontend/lib/hooks/useShareBrain.ts
+++ b/frontend/lib/hooks/useShareBrain.ts
@@ -7,14 +7,8 @@ import { Subscription } from "@/lib/api/brain/brain";
 import { useBrainApi } from "@/lib/api/brain/useBrainApi";
 import { useToast } from "@/lib/hooks";
 
-import {
-  BrainRoleAssignation,
-  BrainRoleType,
-} from "../components/BrainUsers/types";
+import { BrainRoleAssignation } from "../components/BrainUsers/types";
 import { generateBrainAssignation } from "../components/ShareBrain/utils/generateBrainAssignation";
-import { useBrainContext } from "../context/BrainProvider/hooks/useBrainContext";
-
-const requiredAccessToShareBrain: BrainRoleType[] = ["Owner", "Editor"];
 
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const useShareBrain = (brainId: string) => {
@@ -30,11 +24,6 @@ export const useShareBrain = (brainId: string) => {
 
   const { publish } = useToast();
   const { addBrainSubscriptions } = useBrainApi();
-
-  const { allBrains } = useBrainContext();
-  const hasShareBrainRights = requiredAccessToShareBrain.includes(
-    allBrains.find((brain) => brain.id === brainId)?.role ?? "Viewer"
-  );
 
   const handleCopyInvitationLink = async () => {
     await navigator.clipboard.writeText(brainShareLink);
@@ -132,6 +121,5 @@ export const useShareBrain = (brainId: string) => {
     setIsShareModalOpen,
     isShareModalOpen,
     canAddNewRow,
-    hasShareBrainRights,
   };
 };


### PR DESCRIPTION
# Description

- Fixes the following issues: 
  - When I acces a brain shared with me as viewer, I should be able to fetch the brain settings from the BE
  - When I access a public brain, if im not owner or editor I should not be able to see the tabs "People" nor "Knowledge"
  - When I access a private brain, if im not owner or editor I should be able to see the tabs "People" or "Knowledge" with a no access - resquest access from owner message