### PR TITLE
fix: text not clear in dark mode

### DIFF
--- a/frontend/app/chat/[chatId]/components/ChatDialogueArea/components/ChatDialogue/components/QADisplay/components/MessageRow/components/MessageContent.tsx
+++ b/frontend/app/chat/[chatId]/components/ChatDialogueArea/components/ChatDialogue/components/QADisplay/components/MessageRow/components/MessageContent.tsx
@@ -45,7 +45,7 @@ export const MessageContent = ({
           <ReactMarkdown>{logs}</ReactMarkdown>
         </div>
       )}
-      <ReactMarkdown className={`text-sm text-gray-800 ${markdownClasses}`}>{cleanedText}</ReactMarkdown>
+      <ReactMarkdown className={`text-sm ${markdownClasses}`}>{cleanedText}</ReactMarkdown>
     </div>
   );
 };


### PR DESCRIPTION
# Description
Text color was being overridden.

Removed `text-gray-800` in MessageContent.tsx.

## Checklist before requesting a review

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

## Screenshots (if appropriate):
Before:
![287382835-049862f4-a5b3-4899-88fa-569edade0e66](https://github.com/StanGirard/quivr/assets/32915176/f81c30f1-a4ad-4e25-a2a8-cce705ec3966)

After:
![image](https://github.com/StanGirard/quivr/assets/32915176/472bf6ed-1739-40be-85e2-1ccda4515043)




