### PR TITLE
doc: add VirtioFS instruction for MacOS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ You can find the installation video [here](https://www.youtube.com/watch?v=cXBa6
   # docker compose -f docker-compose-ollama.yml up --build  # Only if using Ollama. You need to run `ollama run llama2` first.
   ```
 
+  If you have a Mac, go to Docker Desktop > Settings > General and check that the "file sharing implementation" is set to `VirtioFS`.
+
   If you are a developer, you can run the project in development mode with the following command: `docker compose -f docker-compose.dev.yml up --build`
 
 - **Step 5**: Login to the app


### PR DESCRIPTION
# Description

There is a missing setup instruction in the README for MacOS users.

If the filesystem is not set to VirtioFS in Docker Desktop, a SupaBase error is triggered:
`The file system does not support extended attributes or has the feature disabled` 

Supabase related issue: https://github.com/orgs/supabase/discussions/9539

## Checklist before requesting a review

Please delete options that are not relevant.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented hard-to-understand areas
- [x] I have ideally added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged
