### PR TITLE
fix(ollama): - update supabase-db postgres docker image version

### DIFF
--- a/docker-compose-ollama.yml
+++ b/docker-compose-ollama.yml
@@ -439,7 +439,7 @@ services:
   # Comment out everything below this point if you are using an external Postgres database
   db:
     container_name: supabase-db
-    image: supabase/postgres:15.1.0.117
+    image: supabase/postgres:15.1.0.136
     healthcheck:
       test: pg_isready -U postgres -h localhost
       interval: 5s


### PR DESCRIPTION
# Description

I tried to use the Quivr with the docker-compose-ollama.yml option but the docker compose build crashed with the following messages:

`{"code":"58P01","details":null,"hint":null,"message":"could not access file \"$libdir/wrappers-0.1.19\": No such file or directory"}`

After a quick search I saw that the issue was related to the supabase/postgres image and after a quick compare with the default docker-compose.yml i saw that it uses a newer version for the supabase/postgres image and when i tried the newer version with the docker-compose-ollama.yml the errors stopped and the app works fine.

Relative issues: #1846 #1822 #1850
