### PR TITLE
Fix typo of UI: Ressources ==> Resources

### DIFF
--- a/frontend/public/locales/en/brain.json
+++ b/frontend/public/locales/en/brain.json
@@ -51,7 +51,7 @@
   "public_brain_subscribe_button_label": "Subscribe",
   "public_brain_subscription_success_message": "You have successfully subscribed to the brain",
   "public_brains_search_bar_placeholder": "Search public brains",
-  "resources": "Ressource",
+  "resources": "Resources",
   "searchBrain": "Search for a brain",
   "secrets_update_error": "Error while updating secrets",
   "secrets_updated": "Secrets updated",

--- a/frontend/public/locales/fr/brain.json
+++ b/frontend/public/locales/fr/brain.json
@@ -51,7 +51,7 @@
   "public_brain_subscribe_button_label": "S'abonner",
   "public_brain_subscription_success_message": "Vous vous êtes abonné avec succès au cerveau",
   "public_brains_search_bar_placeholder": "Rechercher des cerveaux publics",
-  "resources": "Ressources",
+  "resources": "Resources",
   "searchBrain": "Rechercher un cerveau",
   "secrets_update_error": "Erreur lors de la mise à jour des secrets",
   "secrets_updated": "Secrets mis à jour",


### PR DESCRIPTION
# Description
Typo in UI when creating new brain: "Ressources" ==> "Resources"

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

## Checklist before requesting a review

Please delete options that are not relevant.

- [ ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my code
- [ ] I have commented hard-to-understand areas
- [ ] I have ideally added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

## Screenshots (if appropriate):
![image](https://github.com/StanGirard/quivr/assets/1928741/b6d4282f-8438-408d-bd91-8f8f631bdedd)
